### PR TITLE
Add NPM_MIRROR env var to NodeJS images

### DIFF
--- a/0.10/README.md
+++ b/0.10/README.md
@@ -94,6 +94,7 @@ DEV_MODE    | When set to "true", `nodemon` will be used to automatically reload
 NPM_RUN     | Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
 HTTP_PROXY  | use an npm proxy during assembly
 HTTPS_PROXY | use an npm proxy during assembly
+NPM_MIRROR  | use a custom NPM registry mirror to download packages during the build process
 
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 

--- a/0.10/s2i/bin/assemble
+++ b/0.10/s2i/bin/assemble
@@ -41,6 +41,11 @@ if [ ! -z $https_proxy ]; then
 	npm config set https-proxy $https_proxy
 fi
 
+# Change the npm registry mirror if provided
+if [ -n "$NPM_MIRROR" ]; then
+	npm config set registry $NPM_MIRROR
+fi
+
 echo "---> Building your Node application from source"
 npm install -d
 


### PR DESCRIPTION
The NPM_MIRROR is introduced to allow users to use alternative custom
NPM registry mirror during the build process. The NPM packages will be
downloaded from the custom link instead of the default 'registry.npmjs.org'.

Signed-off-by: Vu Dinh <vdinh@redhat.com>