### PR TITLE
disable gpg signed commits (if enabled) when generating test artifacts

### DIFF
--- a/0.10/test/run
+++ b/0.10/test/run
@@ -49,7 +49,7 @@ prepare() {
   pushd ${test_dir}/test-app >/dev/null
   git init
   git config user.email "build@localhost" && git config user.name "builder"
-  git add -A && git commit -m "Sample commit"
+  git add -A && git commit --no-gpg-sign -m "Sample commit"
   popd >/dev/null
 }
 


### PR DESCRIPTION
I have 'signed commits' enabled on my dev machine, but I don't want `make test` to prompt me for my signing key while running tests