### PR TITLE
Add bzip2 to Dockerfiles

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -27,7 +27,7 @@ LABEL summary="Platform for building and running Node.js 4 applications" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858"
 
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon nss_wrapper" && \
+    INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon nss_wrapper bzip2" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -34,7 +34,7 @@ LABEL com.redhat.component="rh-nodejs4-docker" \
 RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon nss_wrapper" && \
+    INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon nss_wrapper bzip2" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \


### PR DESCRIPTION
Customer can't use the image, because the bzip2 package is missing.
https://bugzilla.redhat.com/show_bug.cgi?id=1364546