### PR TITLE
Allow to select more than one version to build

### DIFF
--- a/hack/common.mk
+++ b/hack/common.mk
@@ -13,7 +13,7 @@ script_env = \
 	UPDATE_BASE=$(UPDATE_BASE)                      \
 	VERSIONS="$(VERSIONS)"                          \
 	OS=$(OS)                                        \
-	VERSION=$(VERSION)                              \
+	VERSION="$(VERSION)"                            \
 	BASE_IMAGE_NAME=$(BASE_IMAGE_NAME)              \
 	OPENSHIFT_NAMESPACES="$(OPENSHIFT_NAMESPACES)"
 


### PR DESCRIPTION
This PR allows to specify more versions to build in VERSION variable. Without this it is not possible.

Also for some repositories fixes lack of simmilar PR as sclorg/mongodb-container#208.


@hhorak Please merge.