### PR TITLE
Enable OSE repo for nss_wrapper.

### DIFF
--- a/0.10/Dockerfile.rhel7
+++ b/0.10/Dockerfile.rhel7
@@ -36,6 +36,7 @@ LABEL com.redhat.component="nodejs010" \
 RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="nodejs010 nodejs010-nodejs-nodemon bzip2 nss_wrapper" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -36,6 +36,7 @@ LABEL com.redhat.component="rh-nodejs4-docker" \
 RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \


### PR DESCRIPTION
In RHEL7 Dockerfile nss_wrapper is installed but OSE repository is not enabled. So installation fails.

@hhorak @bparees Please take a look and merge.