### PR TITLE
Update Dockerfiles

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -3,8 +3,6 @@ FROM centos/s2i-base-centos7
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
 
-LABEL MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -33,7 +31,12 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,nodejs,nodejs$NODEJS_VERSION" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="/opt/app-root/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858"
+      com.redhat.dev-mode.port="DEBUG_PORT:5858" \
+      com.redhat.component="rh-nodejs4-docker" \
+      name="centos/nodejs-4-centos7" \
+      version="4" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 RUN yum install -y centos-release-scl-rh && \
     INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon nss_wrapper" && \

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -31,14 +31,11 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,nodejs,nodejs$NODEJS_VERSION" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="/opt/app-root/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-nodejs4-docker" \
+      com.redhat.dev-mode.port="DEBUG_PORT:5858" \
+      com.redhat.component="rh-nodejs4-docker" \
       name="rhscl/nodejs-4-rhel7" \
       version="4" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -3,8 +3,6 @@ FROM centos/s2i-base-centos7
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
 
-LABEL MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -33,7 +31,12 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,nodejs,nodejs$NODEJS_VERSION" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="/opt/app-root/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858"
+      com.redhat.dev-mode.port="DEBUG_PORT:5858"\
+      com.redhat.component="rh-nodejs6-docker" \
+      name="centos/nodejs-6-centos7" \
+      version="6" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --enable centos-sclo-rh-testing && \

--- a/6/Dockerfile.rhel7
+++ b/6/Dockerfile.rhel7
@@ -31,14 +31,11 @@ LABEL summary="$SUMMARY" \
       io.openshift.tags="builder,nodejs,nodejs$NODEJS_VERSION" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="/opt/app-root/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858"
-
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-nodejs6-docker" \
+      com.redhat.dev-mode.port="DEBUG_PORT:5858" \
+      com.redhat.component="rh-nodejs6-docker" \
       name="rhscl/nodejs-6-rhel7" \
       version="6" \
-      release="14.1" \
-      architecture="x86_64"
+      release="14.1"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553


### PR DESCRIPTION
Provide same labels for all base image variants (CentOS, RHEL, Fedora)
 - follow recomended labels from Project Atomic Container best practices
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)

@hhorak @praiskup @pkubatrh Please take a look and merge.