### PR TITLE
Remove nodejs6 packages in nodejs4 image

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -39,6 +39,7 @@ LABEL summary="$SUMMARY" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 RUN yum install -y centos-release-scl-rh && \
+    yum remove -y rh-nodejs6\* && \
     INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -44,7 +44,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    yum remove rh-nodejs6\* && \
+    yum remove -y rh-nodejs6\* && \
     INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -44,6 +44,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum remove rh-nodejs6\* && \
     INSTALL_PKGS="rh-nodejs4 rh-nodejs4-npm rh-nodejs4-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
NodeJS 6 gets installed in s2i-base, but it doesn't make sense in rh-nodejs4 image, so this PR removes it.

However, even if this makes the image's content smaller, in the end users might need to download more bytes (me not sure how overlayfs works in case when we install something in one layer and then remove it in another)..

Anyway, I'm personally not entirely convinced whether the space issue is more important than having some packages installed and not used, since there is always some risk of either using wrong packages by mistake, or that a potential attacker will have more tools available.. So, any opinion about this is welcome.