### PR TITLE
Build production ready minimal size images

### DIFF
--- a/0.10/s2i/bin/assemble
+++ b/0.10/s2i/bin/assemble
@@ -47,8 +47,51 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
-echo "---> Building your Node application from source"
-npm install
+# Set the DEV_MODE to false by default.
+if [ -z "$DEV_MODE" ]; then
+  export DEV_MODE=false
+fi
+
+# If NODE_ENV is not set by the user, then NODE_ENV is determined by whether
+# the container is run in development mode.
+if [ -z "$NODE_ENV" ]; then
+  if [ "$DEV_MODE" == true ]; then
+    export NODE_ENV=development
+  else
+    export NODE_ENV=production
+  fi
+fi
+
+if [ "$NODE_ENV" != "production" ]; then
+
+	echo "---> Building your Node application from source"
+	npm install
+
+else
+
+	echo "---> Installing all dependencies"
+	NODE_ENV=development npm install
+
+	#do not fail when there is no build script
+	echo "---> Building in production mode"
+	npm run build --if-present
+
+	echo "---> Pruning the development dependencies"
+	npm prune
+
+	# Clear the npm's cache and tmp directories only if they are not a docker volumes
+	NPM_CACHE=$(npm config get cache)
+	if ! mountpoint $NPM_CACHE; then
+		echo "---> Cleaning the npm cache $NPM_CACHE"
+		npm cache clean
+	fi
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
+fi
 
 # Fix source directory permissions
 fix-permissions ./

--- a/4/s2i/bin/assemble
+++ b/4/s2i/bin/assemble
@@ -55,8 +55,51 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
-echo "---> Building your Node application from source"
-npm install
+# Set the DEV_MODE to false by default.
+if [ -z "$DEV_MODE" ]; then
+  export DEV_MODE=false
+fi
+
+# If NODE_ENV is not set by the user, then NODE_ENV is determined by whether
+# the container is run in development mode.
+if [ -z "$NODE_ENV" ]; then
+  if [ "$DEV_MODE" == true ]; then
+    export NODE_ENV=development
+  else
+    export NODE_ENV=production
+  fi
+fi
+
+if [ "$NODE_ENV" != "production" ]; then
+
+	echo "---> Building your Node application from source"
+	npm install
+
+else
+
+	echo "---> Installing all dependencies"
+	NODE_ENV=development npm install
+
+	#do not fail when there is no build script
+	echo "---> Building in production mode"
+	npm run build --if-present
+
+	echo "---> Pruning the development dependencies"
+	npm prune
+
+	# Clear the npm's cache and tmp directories only if they are not a docker volumes
+	NPM_CACHE=$(npm config get cache)
+	if ! mountpoint $NPM_CACHE; then
+		echo "---> Cleaning the npm cache $NPM_CACHE"
+		npm cache clean
+	fi
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
+fi
 
 # Fix source directory permissions
 fix-permissions ./

--- a/6/s2i/bin/assemble
+++ b/6/s2i/bin/assemble
@@ -55,8 +55,51 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
-echo "---> Building your Node application from source"
-npm install
+# Set the DEV_MODE to false by default.
+if [ -z "$DEV_MODE" ]; then
+  export DEV_MODE=false
+fi
+
+# If NODE_ENV is not set by the user, then NODE_ENV is determined by whether
+# the container is run in development mode.
+if [ -z "$NODE_ENV" ]; then
+  if [ "$DEV_MODE" == true ]; then
+    export NODE_ENV=development
+  else
+    export NODE_ENV=production
+  fi
+fi
+
+if [ "$NODE_ENV" != "production" ]; then
+
+	echo "---> Building your Node application from source"
+	npm install
+
+else
+
+	echo "---> Installing all dependencies"
+	NODE_ENV=development npm install
+
+	#do not fail when there is no build script
+	echo "---> Building in production mode"
+	npm run build --if-present
+
+	echo "---> Pruning the development dependencies"
+	npm prune
+
+	# Clear the npm's cache and tmp directories only if they are not a docker volumes
+	NPM_CACHE=$(npm config get cache)
+	if ! mountpoint $NPM_CACHE; then
+		echo "---> Cleaning the npm cache $NPM_CACHE"
+		npm cache clean
+	fi
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
+fi
 
 # Fix source directory permissions
 fix-permissions ./

--- a/8/s2i/bin/assemble
+++ b/8/s2i/bin/assemble
@@ -85,7 +85,7 @@ else
 	npm run build --if-present
 
 	echo "---> Pruning the development dependencies"
-	npm prune || echo "!!!!!!!! Prune failed. See https://github.com/npm/npm/issues/17781 !!!!!!!!!"
+	npm prune
 
 	# Clear the npm's cache and tmp directories only if they are not a docker volumes
 	NPM_CACHE=$(npm config get cache)

--- a/8/s2i/bin/assemble
+++ b/8/s2i/bin/assemble
@@ -55,8 +55,52 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
-echo "---> Building your Node application from source"
-npm install
+# Set the DEV_MODE to false by default.
+if [ -z "$DEV_MODE" ]; then
+  export DEV_MODE=false
+fi
+
+# If NODE_ENV is not set by the user, then NODE_ENV is determined by whether
+# the container is run in development mode.
+if [ -z "$NODE_ENV" ]; then
+  if [ "$DEV_MODE" == true ]; then
+    export NODE_ENV=development
+  else
+    export NODE_ENV=production
+  fi
+fi
+
+if [ "$NODE_ENV" != "production" ]; then
+
+	echo "---> Building your Node application from source"
+	npm install
+
+else
+
+	echo "---> Installing all dependencies"
+	NODE_ENV=development npm install
+
+	#do not fail when there is no build script
+	echo "---> Building in production mode"
+	npm run build --if-present
+
+	echo "---> Pruning the development dependencies"
+	npm prune || echo "!!!!!!!! Prune failed. See https://github.com/npm/npm/issues/17781 !!!!!!!!!"
+
+	# Clear the npm's cache and tmp directories only if they are not a docker volumes
+	NPM_CACHE=$(npm config get cache)
+	if ! mountpoint $NPM_CACHE; then
+		echo "---> Cleaning the npm cache $NPM_CACHE"
+		#As of npm@5 even the 'npm cache clean --force' does not fully remove the cache directory
+		rm $NPM_CACHE* -rf
+	fi
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
+fi
 
 # Fix source directory permissions
 fix-permissions ./

--- a/test/run
+++ b/test/run
@@ -274,11 +274,8 @@ test_connection
 check_result $?
 
 # Test that the development dependencies (nodemon) have been removed (npm prune)
-# The node v8 comes with npm 5.3.* that has bug and prune fails. See https://github.com/npm/npm/issues/17781
-if [ "v$VERSION" != "v8" ]; then
-	devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! test -d ~/node_modules/nodemon")
-	check_result $?
-fi
+devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! test -d ~/node_modules/nodemon")
+check_result $?
 
 # Test that the npm cache has been cleared
 devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! test -d \$(npm config get cache)")

--- a/test/run
+++ b/test/run
@@ -46,7 +46,7 @@ container_logs() {
 }
 
 run_s2i_build() {
-  s2i build ${s2i_args} file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
+  s2i build ${s2i_args} $1 file://${test_dir}/test-app ${IMAGE_NAME} ${IMAGE_NAME}-testapp
 }
 
 run_s2i_build_proxy() {
@@ -75,6 +75,11 @@ prepare() {
 }
 
 run_test_application() {
+    if [ -f $cid_file ]; then
+        docker kill $(cat $cid_file)
+        rm $cid_file
+    fi
+
     if [[ $1 == app ]]; then
         docker run --user=100001 --rm --cidfile=${cid_file} $2 ${IMAGE_NAME}-testapp
     elif [[ $1 == hw ]]; then
@@ -217,9 +222,32 @@ validate_node_env() {
   fi
 }
 
+test_dev_mode() {
+  local app=$1
+  local dev_mode=$2
+  local node_env=$3
+
+  echo "Testing $app DEV_MODE=$dev_mode NODE_ENV=$node_env"
+
+  run_test_application $app "-e DEV_MODE=$dev_mode" &
+  wait_for_cid
+
+  test_connection
+  check_result $?
+
+  logs=$(container_logs)
+  echo ${logs} | grep -q DEV_MODE=$dev_mode
+  check_result $?
+  echo ${logs} | grep -q DEBUG_PORT=5858
+  check_result $?
+  echo ${logs} | grep -q NODE_ENV=$node_env
+  check_result $?
+}
+
 # Build the application image twice to ensure the 'save-artifacts' and
 # 'restore-artifacts' scripts are working properly
 prepare app
+echo "Testing the production image build"
 run_s2i_build
 check_result $?
 
@@ -243,35 +271,67 @@ check_result $?
 test_connection
 check_result $?
 
-echo "Testing DEV_MODE=false"
-logs=$(container_logs)
-echo ${logs} | grep -q DEV_MODE=false
-check_result $?
-echo ${logs} | grep -q NODE_ENV=production
-check_result $?
-echo ${logs} | grep -q DEBUG_PORT=5858
+# Test that the development dependencies (nodemon) have been removed (npm prune)
+# The node v8 comes with npm 5.3.* that has bug and prune fails. See https://github.com/npm/npm/issues/17781
+if [ "v$VERSION" != "v8" ]; then
+	devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! test -d ~/node_modules/nodemon")
+	check_result $?
+fi
+
+# Test that the npm cache has been cleared
+devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! test -d \$(npm config get cache)")
 check_result $?
 
-docker kill $(cat $cid_file)
-rm $cid_file
+# Test that the npm tmp has been cleared
+devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! ls \$(npm config get tmp)/npm-* 2>/dev/null")
+check_result $?
 
-echo "Testing DEV_MODE=true"
-run_test_application app "-e DEV_MODE=true" &
+test_dev_mode app false production
+test_dev_mode app true development
+
+echo "Testing the development image build: s2i build -e \"NODE_ENV=development\")"
+run_s2i_build "-e NODE_ENV=development"
+check_result $?
+
+# Verify that the HTTP connection can be established to test application container
+run_test_application app &
 wait_for_cid
 
 test_connection
 check_result $?
 
-logs=$(container_logs)
-echo ${logs} | grep -q DEV_MODE=true
-check_result $?
-echo ${logs} | grep -q NODE_ENV=development
-check_result $?
-echo ${logs} | grep -q DEBUG_PORT=5858
+# Test that the development dependencies (nodemon) have NOT been removed
+devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "test -d ~/node_modules/nodemon")
 check_result $?
 
-docker kill $(cat $cid_file)
-rm $cid_file
+# Test that the npm cache has NOT been cleared
+devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "test -d \$(npm config get cache)")
+check_result $?
+
+test_dev_mode app true development
+test_dev_mode app false development
+
+echo "Testing the development image build: s2i build -e \"DEV_MODE=true\")"
+run_s2i_build "-e DEV_MODE=true"
+check_result $?
+
+# Verify that the HTTP connection can be established to test application container
+run_test_application app &
+wait_for_cid
+
+test_connection
+check_result $?
+
+# Test that the development dependencies (nodemon) have NOT been removed
+devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "test -d ~/node_modules/nodemon")
+check_result $?
+
+# Test that the npm cache has NOT been cleared
+devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "test -d \$(npm config get cache)")
+check_result $?
+
+test_dev_mode app true development
+test_dev_mode app false production
 
 echo "Testing proxy safe logging..."
 prepare hw

--- a/test/run
+++ b/test/run
@@ -75,11 +75,6 @@ prepare() {
 }
 
 run_test_application() {
-    if [ -f $cid_file ]; then
-        docker kill $(cat $cid_file)
-        rm $cid_file
-    fi
-
     if [[ $1 == app ]]; then
         docker run --user=100001 --rm --cidfile=${cid_file} $2 ${IMAGE_NAME}-testapp
     elif [[ $1 == hw ]]; then
@@ -88,6 +83,11 @@ run_test_application() {
         echo "No such test application"
         exit 1
     fi
+}
+
+kill_test_application() {
+	docker kill $(cat $cid_file)
+	rm $cid_file
 }
 
 cleanup() {
@@ -135,7 +135,7 @@ test_s2i_usage() {
 
 test_docker_run_usage() {
   echo "Testing 'docker run' usage..."
-  docker run ${IMAGE_NAME} &>/dev/null
+  docker run --rm ${IMAGE_NAME} &>/dev/null
 }
 
 test_connection() {
@@ -242,6 +242,8 @@ test_dev_mode() {
   check_result $?
   echo ${logs} | grep -q NODE_ENV=$node_env
   check_result $?
+
+  kill_test_application
 }
 
 # Build the application image twice to ensure the 'save-artifacts' and
@@ -286,6 +288,8 @@ check_result $?
 devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! ls \$(npm config get tmp)/npm-* 2>/dev/null")
 check_result $?
 
+kill_test_application
+
 test_dev_mode app false production
 test_dev_mode app true development
 
@@ -307,6 +311,8 @@ check_result $?
 # Test that the npm cache has NOT been cleared
 devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "test -d \$(npm config get cache)")
 check_result $?
+
+kill_test_application
 
 test_dev_mode app true development
 test_dev_mode app false development
@@ -330,6 +336,8 @@ check_result $?
 devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "test -d \$(npm config get cache)")
 check_result $?
 
+kill_test_application
+
 test_dev_mode app true development
 test_dev_mode app false production
 
@@ -347,10 +355,7 @@ fi
 
 run_test_application hw &
 wait_for_cid
-
-docker kill $(cat $cid_file)
-rm $cid_file
-
+kill_test_application
 
 echo "Success!"
 cleanup

--- a/test/run
+++ b/test/run
@@ -10,8 +10,8 @@
 test -n $IMAGE_NAME \
   -a -n $VERSION
 
-test_dir="$(readlink -zf $(dirname ${BASH_SOURCE[0]}))"
-image_dir="$(readlink -zf ${test_dir}/..)"
+test_dir="$(readlink -f $(dirname ${BASH_SOURCE[0]}))"
+image_dir="$(readlink -f ${test_dir}/..)"
 cid_file=$(mktemp -u --suffix=.cid)
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull


### PR DESCRIPTION
To build in production mode start s2i with `-e "NODE_ENV=production"`

- First install all dependencies
- Then call the build script in production mode
- Prune development dependencies
- Clear the npm's cache and tmp directories if they are not docker volumes
