### PR TITLE
tests: replace removed s2i flag

### DIFF
--- a/test/run
+++ b/test/run
@@ -16,7 +16,7 @@ cid_file=$(mktemp -u --suffix=.cid)
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false "
+s2i_args="--pull-policy=never "
 
 # TODO: This should be part of the image metadata
 test_port=8080


### PR DESCRIPTION
Similarily to: sclorg/s2i-python-container#229