### PR TITLE
Various small documentation related changes

### DIFF
--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -39,7 +39,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
-      com.redhat.deployments-dir="/opt/app-root/src" \
+      com.redhat.deployments-dir="${APP_ROOT}/src" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858"\
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="centos/$NAME-$NODEJS_VERSION-centos7" \
@@ -64,7 +64,7 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
     rpm-file-permissions
 
 USER 1001

--- a/4/Dockerfile
+++ b/4/Dockerfile
@@ -44,7 +44,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="centos/$NAME-$NODEJS_VERSION-centos7" \
       version="$NODEJS_VERSION" \
-      release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> centos/$NAME-$NODEJS_VERSION-centos7:latest <APP-NAME>"

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -44,7 +44,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="rhscl/$NAME-$NODEJS_VERSION-rhel7" \
       version="$NODEJS_VERSION" \
-      release="14.1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> rhscl/$NAME-$NODEJS_VERSION-rhel7:latest <APP-NAME>"

--- a/4/Dockerfile.rhel7
+++ b/4/Dockerfile.rhel7
@@ -39,7 +39,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
-      com.redhat.deployments-dir="/opt/app-root/src" \
+      com.redhat.deployments-dir="${APP_ROOT}/src" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858" \
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="rhscl/$NAME-$NODEJS_VERSION-rhel7" \
@@ -67,7 +67,7 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
     rpm-file-permissions
 
 USER 1001

--- a/4/README.md
+++ b/4/README.md
@@ -47,14 +47,23 @@ Environment variables
 
 Application developers can use the following environment variables to configure the runtime behavior of this image:
 
-NAME        | Description
-------------|-------------
-NODE_ENV    | NodeJS runtime mode (default: "production")
-DEV_MODE    | When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
-NPM_RUN     | Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
-HTTP_PROXY  | Use an npm proxy during assembly
-HTTPS_PROXY | Use an npm proxy during assembly
-NPM_MIRROR  | Use a custom NPM registry mirror to download packages during the build process
+**`NODE_ENV`**  
+       NodeJS runtime mode (default: "production")
+
+**`DEV_MODE`**  
+       When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
+
+**`NPM_RUN`**  
+       Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
+**`HTTP_PROXY`**  
+       Use an npm proxy during assembly
+
+**`HTTPS_PROXY`**  
+       Use an npm proxy during assembly
+
+**`NPM_MIRROR`**  
+       Use a custom NPM registry mirror to download packages during the build process
 
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -39,7 +39,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
-      com.redhat.deployments-dir="/opt/app-root/src" \
+      com.redhat.deployments-dir="${APP_ROOT}/src" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858"\
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="centos/$NAME-$NODEJS_VERSION-centos7" \
@@ -63,8 +63,9 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
     rpm-file-permissions
+
 USER 1001
 
 # Set the default CMD to print the usage of the language image

--- a/6/Dockerfile
+++ b/6/Dockerfile
@@ -44,7 +44,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="centos/$NAME-$NODEJS_VERSION-centos7" \
       version="$NODEJS_VERSION" \
-      release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> centos/$NAME-$NODEJS_VERSION-centos7:latest <APP-NAME>"

--- a/6/Dockerfile.rhel7
+++ b/6/Dockerfile.rhel7
@@ -39,7 +39,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
-      com.redhat.deployments-dir="/opt/app-root/src" \
+      com.redhat.deployments-dir="${APP_ROOT}/src" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858" \
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="rhscl/$NAME-$NODEJS_VERSION-rhel7" \
@@ -66,7 +66,7 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
     rpm-file-permissions
 
 USER 1001

--- a/6/Dockerfile.rhel7
+++ b/6/Dockerfile.rhel7
@@ -44,7 +44,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="rhscl/$NAME-$NODEJS_VERSION-rhel7" \
       version="$NODEJS_VERSION" \
-      release="14.1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> rhscl/$NAME-$NODEJS_VERSION-rhel7:latest <APP-NAME>"

--- a/6/README.md
+++ b/6/README.md
@@ -47,14 +47,23 @@ Environment variables
 
 Application developers can use the following environment variables to configure the runtime behavior of this image:
 
-NAME        | Description
-------------|-------------
-NODE_ENV    | NodeJS runtime mode (default: "production")
-DEV_MODE    | When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
-NPM_RUN     | Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
-HTTP_PROXY  | Use an npm proxy during assembly
-HTTPS_PROXY | Use an npm proxy during assembly
-NPM_MIRROR  | Use a custom NPM registry mirror to download packages during the build process
+**`NODE_ENV`**  
+       NodeJS runtime mode (default: "production")
+
+**`DEV_MODE`**  
+       When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
+
+**`NPM_RUN`**  
+       Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
+**`HTTP_PROXY`**  
+       Use an npm proxy during assembly
+
+**`HTTPS_PROXY`**  
+       Use an npm proxy during assembly
+
+**`NPM_MIRROR`**  
+       Use a custom NPM registry mirror to download packages during the build process
 
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -39,7 +39,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
-      com.redhat.deployments-dir="/opt/app-root/src" \
+      com.redhat.deployments-dir="${APP_ROOT}/src" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858"\
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="centos/$NAME-$NODEJS_VERSION-centos7" \
@@ -64,7 +64,7 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
     rpm-file-permissions
 
 USER 1001

--- a/8/Dockerfile
+++ b/8/Dockerfile
@@ -44,7 +44,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="centos/$NAME-$NODEJS_VERSION-centos7" \
       version="$NODEJS_VERSION" \
-      release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> centos/$NAME-$NODEJS_VERSION-centos7:latest <APP-NAME>"

--- a/8/Dockerfile.rhel7
+++ b/8/Dockerfile.rhel7
@@ -44,7 +44,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="rhscl/$NAME-$NODEJS_VERSION-rhel7" \
       version="$NODEJS_VERSION" \
-      release="1" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> rhscl/$NAME-$NODEJS_VERSION-rhel7:latest <APP-NAME>"

--- a/8/Dockerfile.rhel7
+++ b/8/Dockerfile.rhel7
@@ -39,7 +39,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.s2i.scripts-url="image:///usr/libexec/s2i" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
-      com.redhat.deployments-dir="/opt/app-root/src" \
+      com.redhat.deployments-dir="${APP_ROOT}/src" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858" \
       com.redhat.component="rh-$NAME$NODEJS_VERSION-docker" \
       name="rhscl/$NAME-$NODEJS_VERSION-rhel7" \
@@ -67,7 +67,7 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
     rpm-file-permissions
 
 USER 1001

--- a/8/README.md
+++ b/8/README.md
@@ -1,12 +1,23 @@
-NodeJS Docker image
+NodeJS 8 Docker image
 ===================
 
-This repository contains the source for building various versions of
-the Node.JS application as a reproducible Docker image using
-[source-to-image](https://github.com/openshift/source-to-image).
+This container image includes Node.JS 8 as a [S2I](https://github.com/openshift/source-to-image) base image for your Node.JS 8 applications.
 Users can choose between RHEL and CentOS based builder images.
+The RHEL image is available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-8-rhel7)
+as registry.access.redhat.com/rhscl/nodejs-8-rhel7.
+The CentOS image is then available on [Docker Hub](https://hub.docker.com/r/centos/nodejs-8-centos7/)
+as centos/nodejs-8-centos7. 
 The resulting image can be run using [Docker](http://docker.io).
 
+Description
+-----------
+
+Node.js 8 available as docker container is a base platform for 
+building and running various Node.js 8 applications and frameworks. 
+Node.js is a platform built on Chrome's JavaScript runtime for easily building 
+fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model 
+that makes it lightweight and efficient, perfect for data-intensive real-time applications 
+that run across distributed devices.
 
 Usage
 ---------------------
@@ -31,69 +42,28 @@ resulting image with [Docker](http://docker.io) execute:
 $ curl 127.0.0.1:8080
 ```
 
-
-Repository organization
-------------------------
-* **`<nodejs-version>`**
-
-    * **Dockerfile**
-
-        CentOS based Dockerfile.
-
-    * **Dockerfile.rhel7**
-
-        RHEL based Dockerfile. In order to perform build or test actions on this
-        Dockerfile you need to run the action on a properly subscribed RHEL machine.
-
-    * **`s2i/bin/`**
-
-        This folder contains scripts that are run by [S2I](https://github.com/openshift/source-to-image):
-
-        *   **assemble**
-
-            Used to install the sources into the location where the application
-            will be run and prepare the application for deployment (eg. installing
-            modules using npm, etc.)
-
-        *   **run**
-
-            This script is responsible for running the application, by using the
-            application web server.
-
-        *   **usage***
-
-            This script prints the usage of this image.
-
-    * **`contrib/`**
-
-        This folder contains a file with commonly used modules.
-
-    * **`test/`**
-
-        This folder contains the [S2I](https://github.com/openshift/source-to-image)
-        test framework with simple Node.JS echo server.
-
-        * **`test-app/`**
-
-            A simple Node.JS echo server used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
-
-        * **run**
-
-            This script runs the [S2I](https://github.com/openshift/source-to-image) test framework.
-
 Environment variables
 ---------------------
 
 Application developers can use the following environment variables to configure the runtime behavior of this image:
 
-NAME        | Description
-------------|-------------
-NODE_ENV    | NodeJS runtime mode (default: "production")
-DEV_MODE    | When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
-NPM_RUN     | Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
-HTTP_PROXY  | Use an npm proxy during assembly
-HTTPS_PROXY | Use an npm proxy during assembly
-NPM_MIRROR  | Use a custom NPM registry mirror to download packages during the build process
+**`NODE_ENV`**  
+       NodeJS runtime mode (default: "production")
+
+**`DEV_MODE`**  
+       When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
+
+**`NPM_RUN`**  
+       Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
+**`HTTP_PROXY`**  
+       Use an npm proxy during assembly
+
+**`HTTPS_PROXY`**  
+       Use an npm proxy during assembly
+
+**`NPM_MIRROR`**  
+       Use a custom NPM registry mirror to download packages during the build process
 
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
@@ -184,3 +154,10 @@ Below is an example _package.json_ file with the _main_ attribute and _start_ sc
 
 #### Note:
 `oc rsync` is only available in versions 3.1+ of OpenShift.
+
+
+See also
+--------
+Dockerfile and other sources are available on https://github.com/sclorg/s2i-nodejs-container.
+In that repository you also can find another versions of Python environment Dockerfiles.
+Dockerfile for CentOS is called Dockerfile, Dockerfile for RHEL is called Dockerfile.rhel7.

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ Installation
 To build a Node.JS image, choose either the CentOS or RHEL based image:
 *  **RHEL based image**
 
-    This image is available in Red Hat Container Registry. To download it run:
+    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/nodejs-8-rhel7).
+    To download it run:
 
     ```
-    $ docker pull registry.access.redhat.com/rhscl/nodejs-6-rhel7
+    $ docker pull registry.access.redhat.com/rhscl/nodejs-8-rhel7
     ```
 
     To build a RHEL based Node.JS image, you need to run the build on a properly
@@ -48,7 +49,7 @@ To build a Node.JS image, choose either the CentOS or RHEL based image:
     $ git clone --recursive https://github.com/sclorg/s2i-nodejs-container.git
     $ cd s2i-nodejs-container
     $ git submodule update --init
-    $ make build TARGET=rhel7 VERSIONS=6
+    $ make build TARGET=rhel7 VERSIONS=8
     ```
 
 *  **CentOS based image**
@@ -56,7 +57,7 @@ To build a Node.JS image, choose either the CentOS or RHEL based image:
     This image is available on DockerHub. To download it run:
 
     ```
-    $ docker pull centos/nodejs-6-centos7
+    $ docker pull centos/nodejs-8-centos7
     ```
 
     To build a Node.JS image from scratch run:
@@ -65,7 +66,7 @@ To build a Node.JS image, choose either the CentOS or RHEL based image:
     $ git clone --recursive https://github.com/sclorg/s2i-nodejs-container.git
     $ cd s2i-nodejs-container
     $ git submodule update --init
-    $ make build TARGET=centos7 VERSIONS=6
+    $ make build TARGET=centos7 VERSIONS=8
     ```
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed
@@ -97,7 +98,7 @@ Users can choose between testing a Node.JS test application based on a RHEL or C
     ```
     $ cd s2i-nodejs-container
     $ git submodule update --init
-    $ make test TARGET=rhel7 VERSIONS=6
+    $ make test TARGET=rhel7 VERSIONS=8
     ```
 
 *  **CentOS based image**
@@ -105,7 +106,7 @@ Users can choose between testing a Node.JS test application based on a RHEL or C
     ```
     $ cd s2i-nodejs-container
     $ git submodule update --init
-    $ make test TARGET=centos7 VERSIONS=6
+    $ make test TARGET=centos7 VERSIONS=8
     ```
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed


### PR DESCRIPTION
Remove release label that is not needed any more
Remove tables in README, because go-md2man cannot convert them properly, and sync README.md content
Few edits in top-level README