### PR TITLE
Bug 1562759 - s2i support for incremental builds

### DIFF
--- a/0.10/s2i/bin/assemble
+++ b/0.10/s2i/bin/assemble
@@ -20,7 +20,7 @@ set -e
 
 shopt -s dotglob
 echo "---> Installing application source ..."
-mv /tmp/src/* ./
+rm -rf ./ && mv /tmp/src/* ./
 
 if [ ! -z $HTTP_PROXY ]; then
 	echo "---> Setting npm http proxy to $HTTP_PROXY"

--- a/4/s2i/bin/assemble
+++ b/4/s2i/bin/assemble
@@ -28,7 +28,7 @@ safeLogging () {
 
 shopt -s dotglob
 echo "---> Installing application source ..."
-mv /tmp/src/* ./
+rm -rf ./ && mv /tmp/src/* ./
 
 if [ ! -z $HTTP_PROXY ]; then
     echo "---> Setting npm http proxy to" $(safeLogging $HTTP_PROXY)

--- a/6/s2i/bin/assemble
+++ b/6/s2i/bin/assemble
@@ -28,7 +28,7 @@ safeLogging () {
 
 shopt -s dotglob
 echo "---> Installing application source ..."
-mv /tmp/src/* ./
+rm -rf ./ && rsync -av /tmp/src/ .
 
 if [ ! -z $HTTP_PROXY ]; then
     echo "---> Setting npm http proxy to" $(safeLogging $HTTP_PROXY)

--- a/8/s2i/bin/assemble
+++ b/8/s2i/bin/assemble
@@ -28,7 +28,7 @@ safeLogging () {
 
 shopt -s dotglob
 echo "---> Installing application source ..."
-mv /tmp/src/* ./
+rm -rf ./ && rsync -av /tmp/src/ .
 
 if [ ! -z $HTTP_PROXY ]; then
     echo "---> Setting npm http proxy to" $(safeLogging $HTTP_PROXY)


### PR DESCRIPTION
The https://bugzilla.redhat.com/show_bug.cgi?id=1562759 reported a use case with incremental builds ~where BuildConfig output ImageStreamTag was chained as an input to another BuildConfig strategy.~

Trying to reproduce the issue discovered potentially another issue in `s2i/bin/assemble` script when it tries to copy the 'source repo' from `/tmp/src/*` into `./`. Given previous build already populated files into `./`, using `rsync` instead of `mv` could fix the following problem:
```
$ oc get pods
NAME          READY     STATUS      RESTARTS   AGE
bc1-1-build   0/1       Completed   0          18s
bc2-1-build   0/1       Error       0          13s

$ oc logs bc2-1-build
---> Installing application source ...
mv: cannot move '/tmp/src/.git' to './.git': Directory not empty
error: build error: non-zero (13) exit code from docker-registry.default.svc:5000/test/is1@sha256:163868c8004d41dad4560999999481a797def73190a7a5f9191754ab029d262c
```

Adding a reference to https://github.com/openshift/jenkins/pull/565 in another s2i image, where this pattern was used in similar situation.

cc: @bparees , @gabemontero 