### PR TITLE
OKD rebranding and sclorg move

### DIFF
--- a/6/README.md
+++ b/6/README.md
@@ -118,7 +118,7 @@ After you [Docker exec](http://docker.io) into the running container, your curre
 
 ### Using OpenShift's rsync
 
-If you have deployed the container to OpenShift, you can use [oc rsync](https://docs.openshift.org/latest/dev_guide/copy_files_to_container.html) to copy local files to a remote container running in an OpenShift pod.
+If you have deployed the container to OpenShift, you can use [oc rsync](https://docs.okd.io/latest/dev_guide/copy_files_to_container.html) to copy local files to a remote container running in an OpenShift pod.
 
 #### Warning:
 

--- a/8/README.md
+++ b/8/README.md
@@ -118,7 +118,7 @@ After you [Docker exec](http://docker.io) into the running container, your curre
 
 ### Using OpenShift's rsync
 
-If you have deployed the container to OpenShift, you can use [oc rsync](https://docs.openshift.org/latest/dev_guide/copy_files_to_container.html) to copy local files to a remote container running in an OpenShift pod.
+If you have deployed the container to OpenShift, you can use [oc rsync](https://docs.okd.io/latest/dev_guide/copy_files_to_container.html) to copy local files to a remote container running in an OpenShift pod.
 
 #### Warning:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Users can choose between RHEL and CentOS based builder images.
 The resulting image can be run using [Docker](http://docker.io).
 
 For more information about using these images with OpenShift, please see the
-official [OpenShift Documentation](https://docs.openshift.org/latest/using_images/s2i_images/nodejs.html).
+official [OpenShift Documentation](https://docs.okd.io/latest/using_images/s2i_images/nodejs.html).
 
 For more information about contributing, see
 [the Contribution Guidelines](https://github.com/sclorg/welcome/blob/master/contribution.md).

--- a/imagestreams/nodejs-centos7.json
+++ b/imagestreams/nodejs-centos7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "supports":"nodejs",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,nodejs",
           "supports":"nodejs:0.10,nodejs:0.1,nodejs",
           "version": "0.10",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,nodejs",
           "supports":"nodejs:4,nodejs",
           "version": "4",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,nodejs",
           "supports":"nodejs:6,nodejs",
           "version": "6",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -97,7 +97,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "8",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/imagestreams/nodejs-rhel7.json
+++ b/imagestreams/nodejs-rhel7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "supports":"nodejs",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,nodejs",
           "supports":"nodejs:0.10,nodejs:0.1,nodejs",
           "version": "0.10",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "hidden,builder,nodejs",
           "supports":"nodejs:4,nodejs",
           "version": "4",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "builder,nodejs",
           "supports":"nodejs:6,nodejs",
           "version": "6",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -97,7 +97,7 @@
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "8",
-          "sampleRepo": "https://github.com/openshift/nodejs-ex.git"
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/test/run-openshift
+++ b/test/run-openshift
@@ -19,4 +19,4 @@ test -n "${VERSION-}" || false 'make sure $VERSION is defined'
 ct_os_cluster_up
 # TODO: We can make the tests work against examples inside the same PR
 ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/s2i-nodejs-container.git" test/test-app "This is a node.js echo service"
-ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/openshift/nodejs-ex.git" . "Welcome to your Node.js application on OpenShift"
+ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/nodejs-ex.git" . "Welcome to your Node.js application on OpenShift"


### PR DESCRIPTION
`docs.openshift.org` to `docs.okd.io`
`github.com/openshift/nodejs-ex` to `github.com/sclorg/nodejs-ex`