### PR TITLE
Do not remove .npmrc file

### DIFF
--- a/10/s2i/bin/assemble
+++ b/10/s2i/bin/assemble
@@ -100,7 +100,9 @@ else
 	if ! mountpoint $NPM_CACHE; then
 		echo "---> Cleaning the npm cache $NPM_CACHE"
 		#As of npm@5 even the 'npm cache clean --force' does not fully remove the cache directory
-		rm $NPM_CACHE* -rf
+		# instead of $NPM_CACHE* use $NPM_CACHE/*.
+		# We do not want to delete .npmrc file.
+		rm -rf "${NPM_CACHE:?}/"
 	fi
 	NPM_TMP=$(npm config get tmp)
 	if ! mountpoint $NPM_TMP; then

--- a/8/s2i/bin/assemble
+++ b/8/s2i/bin/assemble
@@ -100,7 +100,9 @@ else
 	if ! mountpoint $NPM_CACHE; then
 		echo "---> Cleaning the npm cache $NPM_CACHE"
 		#As of npm@5 even the 'npm cache clean --force' does not fully remove the cache directory
-		rm $NPM_CACHE* -rf
+		# instead of $NPM_CACHE* use $NPM_CACHE/*.
+		# We do not want to delete .npmrc file.
+		rm -rf "${NPM_CACHE:?}/"
 	fi
 	NPM_TMP=$(npm config get tmp)
 	if ! mountpoint $NPM_TMP; then

--- a/test/run
+++ b/test/run
@@ -312,10 +312,6 @@ check_result $?
 devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! ls \$(npm config get tmp)/npm-* 2>/dev/null")
 check_result $?
 
-echo "Testing npm availability"
-ct_npm_works
-check_result $?
-
 kill_test_application
 
 test_dev_mode app false production
@@ -387,6 +383,10 @@ kill_test_application
 
 echo "Testing incremental build"
 test_incremental_build
+
+echo "Testing npm availability"
+ct_npm_works
+check_result $?
 
 echo "Success!"
 cleanup


### PR DESCRIPTION
function $NPM_CACHE* removes also
.npmrc file which is not needed. We need
them if `npm config set registry` is called.

Required: container-common-scripts#129

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>