### PR TITLE
Backport few changes previously done in RHOAR container

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -20,6 +20,9 @@ ENV NODEJS_VERSION=10 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    DEBUG_PORT=5858 \
+    CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nodejs \
+    NODEJS_PREFIX=/opt/rh/rh-$NAME$NODEJS_VERSION/root/usr \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
 ENV SUMMARY="Platform for building and running Node.js $NODEJS_VERSION applications" \
@@ -40,7 +43,7 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="${APP_ROOT}/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858"\
+      com.redhat.dev-mode.port="DEBUG_PORT:${DEBUG_PORT}"\
       com.redhat.component="rh-$NAME$NODEJS_VERSION-container" \
       name="centos/$NAME-$NODEJS_VERSION-centos7" \
       version="$NODEJS_VERSION" \
@@ -51,7 +54,6 @@ LABEL summary="$SUMMARY" \
 RUN yum install -y centos-release-scl-rh && \
     ( [ "rh-${NAME}${NODEJS_VERSION}" != "${NODEJS_SCL}" ] && yum remove -y ${NODEJS_SCL}\* || : ) && \
     INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
-    ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
@@ -62,9 +64,8 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image, including help file.
 COPY ./root/ /
 
-# Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
-    rpm-file-permissions
+# Run further installation commands
+RUN ${CONTAINER_SCRIPTS_PATH}/nodejs_container_install
 
 USER 1001
 

--- a/10/Dockerfile.fedora
+++ b/10/Dockerfile.fedora
@@ -20,6 +20,9 @@ ENV NODEJS_VERSION=10 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    DEBUG_PORT=5858 \
+    CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nodejs \
+    NODEJS_PREFIX=/usr \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
 ENV SUMMARY="Platform for building and running Node.js $NODEJS_VERSION applications" \
@@ -40,7 +43,7 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="${APP_ROOT}/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858"\
+      com.redhat.dev-mode.port="DEBUG_PORT:${DEBUG_PORT}"\
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
@@ -68,9 +71,8 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image, including help file.
 COPY ./root/ /
 
-# Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
-    rpm-file-permissions
+# Run further installation commands
+RUN ${CONTAINER_SCRIPTS_PATH}/nodejs_container_install
 
 USER 1001
 

--- a/10/Dockerfile.fedora
+++ b/10/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f29/s2i-base:latest
+FROM registry.fedoraproject.org/f31/s2i-base:latest
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.

--- a/10/Dockerfile.rhel7
+++ b/10/Dockerfile.rhel7
@@ -20,6 +20,9 @@ ENV NODEJS_VERSION=10 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    DEBUG_PORT=5858 \
+    CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nodejs \
+    NODEJS_PREFIX=/opt/rh/rh-$NAME$NODEJS_VERSION/root/usr \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
 ENV SUMMARY="Platform for building and running Node.js $NODEJS_VERSION applications" \
@@ -40,7 +43,7 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="${APP_ROOT}/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858" \
+      com.redhat.dev-mode.port="DEBUG_PORT:${DEBUG_PORT}"\
       com.redhat.component="rh-${NAME}${NODEJS_VERSION}-container" \
       name="rhscl/$NAME-$NODEJS_VERSION-rhel7" \
       version="1" \
@@ -53,7 +56,6 @@ RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
     ( [ "rh-${NAME}${NODEJS_VERSION}" != "${NODEJS_SCL}" ] && yum remove -y ${NODEJS_SCL}\* || : ) && \
     INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
-    ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
@@ -64,9 +66,8 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
-    rpm-file-permissions
+# Run further installation commands
+RUN ${CONTAINER_SCRIPTS_PATH}/nodejs_container_install
 
 USER 1001
 

--- a/10/Dockerfile.rhel8
+++ b/10/Dockerfile.rhel8
@@ -20,6 +20,9 @@ ENV NODEJS_VERSION=10 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    DEBUG_PORT=5858 \
+    CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nodejs \
+    NODEJS_PREFIX=/usr \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
 ENV SUMMARY="Platform for building and running Node.js $NODEJS_VERSION applications" \
@@ -40,7 +43,7 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="${APP_ROOT}/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858" \
+      com.redhat.dev-mode.port="DEBUG_PORT:${DEBUG_PORT}"\
       com.redhat.component="${NAME}-${NODEJS_VERSION}-container" \
       name="ubi8/$NAME-$NODEJS_VERSION" \
       version="1" \
@@ -51,7 +54,6 @@ LABEL summary="$SUMMARY" \
 
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="nodejs npm nodejs-nodemon nss_wrapper" && \
-    ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum remove -y $INSTALL_PKGS && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
@@ -63,9 +65,8 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
-    rpm-file-permissions
+# Run further installation commands
+RUN ${CONTAINER_SCRIPTS_PATH}/nodejs_container_install
 
 USER 1001
 

--- a/10/root/usr/share/container-scripts/nodejs/nodejs_container_install
+++ b/10/root/usr/share/container-scripts/nodejs/nodejs_container_install
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -ex
+
+# Ensure git uses https instead of ssh for NPM install
+# See: https://github.com/npm/npm/issues/5257
+echo -e "Setting git config rules"
+git config --system url."https://github.com".insteadOf git@github.com:
+git config --global url."https://github.com".insteadOf ssh://git@github.com
+git config --system url."https://".insteadOf git://
+git config --system url."https://".insteadOf ssh://
+git config --list
+
+# Since the shebang in the *.js files below is !#/usr/bin/env node, we can
+# just create symlinks and if needed, SCL environment is gonna be enabled properly
+
+# Make sure npx is available on standard path
+if [ ! -h /usr/bin/npx ] ; then
+  ln -s "${NODEJS_PREFIX}/lib/node_modules/npm/bin/npx-cli.js" /usr/bin/npx
+fi
+
+# Make sure nodemon is available on standard path
+if [ ! -h /usr/bin/nodemon ] ; then
+  ln -s "${NODEJS_PREFIX}/lib/node_modules/nodemon/bin/nodemon.js" /usr/bin/nodemon
+fi
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+echo "---> Setting directory write permissions"
+fix-permissions "${APP_ROOT}"
+
+# Fix permissions for files installed by RPM
+rpm-file-permissions

--- a/10/root/usr/share/container-scripts/nodejs/nodejs_container_install
+++ b/10/root/usr/share/container-scripts/nodejs/nodejs_container_install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # Ensure git uses https instead of ssh for NPM install
 # See: https://github.com/npm/npm/issues/5257

--- a/10/s2i/bin/assemble
+++ b/10/s2i/bin/assemble
@@ -135,8 +135,11 @@ else
 
 fi
 
-echo "---> Cleaning up npm cache"
-rm -rf .npm
+# TODO: Do we need cache or not actually?
+# based on the following commit, it doesn't seem so:
+# https://github.com/sclorg/s2i-nodejs-container/commit/0e9b5cbb2fe719c447ed3a96fd534f6b2e2ca888
+# echo "---> Cleaning up npm cache"
+# rm -rf .npm
 
 # Fix source directory permissions
 fix-permissions ./

--- a/10/s2i/bin/assemble
+++ b/10/s2i/bin/assemble
@@ -38,6 +38,10 @@ mv /tmp/src/* ./
 # Fix source directory permissions
 fix-permissions ./
 
+if [ "$DEV_MODE" == true ] ; then
+  set -x
+fi
+
 if [ ! -z $HTTP_PROXY ]; then
     echo "---> Setting npm http proxy to" $(safeLogging $HTTP_PROXY)
 	npm config set proxy $HTTP_PROXY
@@ -60,6 +64,7 @@ fi
 
 # Change the npm registry mirror if provided
 if [ -n "$NPM_MIRROR" ]; then
+	echo "---> Setting the npm package mirror to $NPM_MIRROR"
 	npm config set registry $NPM_MIRROR
 fi
 
@@ -78,19 +83,37 @@ if [ -z "$NODE_ENV" ]; then
   fi
 fi
 
-if [ "$NODE_ENV" != "production" ]; then
+echo -e "Current git config"
+git config --list
+
+if [ -n "$YARN_ENABLED" ]; then
+	echo "---> Using 'yarn install' with YARN_ARGS"
+	yarn install $YARN_ARGS
+
+elif [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
 	npm install
 
+	# Do not fail when there is no build script
+	echo "---> Building in development mode"
+	npm run build --if-present
 else
 
-	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+	HAS_BUILD=$(node -e "console.log(require('./package.json').scripts.build ? true : false)")
 
-	#do not fail when there is no build script
-	echo "---> Building in production mode"
-	npm run build --if-present
+	# Check to see if there is a build script by inspecting the package.json
+	if [ "$HAS_BUILD" == true ]; then
+		# Do a npm install to get the dev depdencies
+		echo "---> Installing dev dependencies"
+		NODE_ENV=development npm install
+		# Do not fail when there is no build script
+		echo "---> Building in production mode"
+		npm run build --if-present
+	else
+		echo "---> Using 'npm install -s --only=production'"
+		npm install -s --only=production
+	fi
 
 	echo "---> Pruning the development dependencies"
 	npm prune
@@ -111,6 +134,9 @@ else
 	fi
 
 fi
+
+echo "---> Cleaning up npm cache"
+rm -rf .npm
 
 # Fix source directory permissions
 fix-permissions ./

--- a/10/s2i/bin/run
+++ b/10/s2i/bin/run
@@ -13,25 +13,32 @@ if [ -e "/opt/app-root/etc/generate_container_user" ]; then
   source /opt/app-root/etc/generate_container_user
 fi
 
+export GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-unknown}"
+export GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-unknown@localhost.com}"
+git --version
+
 # Runs the nodejs application server. If the container is run in development mode,
 # hot deploy and debugging are enabled.
 run_node() {
   echo -e "Environment: \n\tDEV_MODE=${DEV_MODE}\n\tNODE_ENV=${NODE_ENV}\n\tDEBUG_PORT=${DEBUG_PORT}"
+  echo -e "Running as user $(id)"
   if [ "$DEV_MODE" == true ]; then
+    echo "Installing dev dependencies..."
+    npm install
     echo "Launching via nodemon..."
-    exec nodemon --inspect="$DEBUG_PORT"
+    exec npx nodemon --inspect="$DEBUG_PORT"
   else
     echo "Launching via npm..."
     exec npm run -d $NPM_RUN
   fi
 } 
 
-#Set the debug port to 5858 by default.
+# Set the debug port to 5858 by default.
 if [ -z "$DEBUG_PORT" ]; then
   export DEBUG_PORT=5858
 fi
 
-# Set the environment to development by default.
+# Set the DEV_MODE to false by default.
 if [ -z "$DEV_MODE" ]; then
   export DEV_MODE=false
 fi

--- a/10/s2i/bin/usage
+++ b/10/s2i/bin/usage
@@ -3,12 +3,12 @@
 DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
 
 cat <<EOF
-This is a S2I nodejs-8 ${DISTRO} base image:
+This is a S2I nodejs-${NODEJS_VERSION} ${DISTRO} base image:
 To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-s2i build https://github.com/sclorg/s2i-nodejs-container.git --context-dir=8/test/test-app/ ${NAMESPACE}/nodejs-8-${DISTRO}7 nodejs-sample-app
+s2i build https://github.com/sclorg/s2i-nodejs-container.git --context-dir=${NODEJS_VERSION}/test/test-app/ ${NAMESPACE}/nodejs-${NODEJS_VERSION}-${DISTRO} nodejs-sample-app
 
 You can then run the resulting image via:
 podman run -p 8080:8080 nodejs-sample-app

--- a/12/Dockerfile
+++ b/12/Dockerfile
@@ -20,6 +20,9 @@ ENV NODEJS_VERSION=12 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    DEBUG_PORT=5858 \
+    CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nodejs \
+    NODEJS_PREFIX=/opt/rh/rh-$NAME$NODEJS_VERSION/root/usr \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
 ENV SUMMARY="Platform for building and running Node.js $NODEJS_VERSION applications" \
@@ -40,7 +43,7 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="${APP_ROOT}/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858"\
+      com.redhat.dev-mode.port="DEBUG_PORT:${DEBUG_PORT}"\
       com.redhat.component="rh-$NAME$NODEJS_VERSION-container" \
       name="centos/$NAME-$NODEJS_VERSION-centos7" \
       version="$NODEJS_VERSION" \
@@ -51,7 +54,6 @@ LABEL summary="$SUMMARY" \
 RUN yum install -y centos-release-scl-rh && \
     ( [ "rh-${NAME}${NODEJS_VERSION}" != "${NODEJS_SCL}" ] && yum remove -y ${NODEJS_SCL}\* || : ) && \
     INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
-    ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum-config-manager --add-repo https://cbs.centos.org/repos/sclo7-rh-nodejs${NODEJS_VERSION}-rh-candidate/x86_64/os/ && \
     echo gpgcheck=0 >> /etc/yum.repos.d/cbs.centos.org_repos_sclo7-rh-nodejs${NODEJS_VERSION}-rh-candidate_x86_64_os_.repo && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
@@ -64,9 +66,8 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image, including help file.
 COPY ./root/ /
 
-# Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
-    rpm-file-permissions
+# Run further installation commands
+RUN ${CONTAINER_SCRIPTS_PATH}/nodejs_container_install
 
 USER 1001
 

--- a/12/Dockerfile.fedora
+++ b/12/Dockerfile.fedora
@@ -20,6 +20,9 @@ ENV NODEJS_VERSION=12 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    DEBUG_PORT=5858 \
+    CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nodejs \
+    NODEJS_PREFIX=/usr \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
 ENV SUMMARY="Platform for building and running Node.js $NODEJS_VERSION applications" \
@@ -40,7 +43,7 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="${APP_ROOT}/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858"\
+      com.redhat.dev-mode.port="DEBUG_PORT:${DEBUG_PORT}"\
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \
@@ -68,9 +71,8 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image, including help file.
 COPY ./root/ /
 
-# Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
-    rpm-file-permissions
+# Run further installation commands
+RUN ${CONTAINER_SCRIPTS_PATH}/nodejs_container_install
 
 USER 1001
 

--- a/12/Dockerfile.rhel7
+++ b/12/Dockerfile.rhel7
@@ -20,6 +20,9 @@ ENV NODEJS_VERSION=12 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    DEBUG_PORT=5858 \
+    CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nodejs \
+    NODEJS_PREFIX=/opt/rh/rh-$NAME$NODEJS_VERSION/root/usr \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
 ENV SUMMARY="Platform for building and running Node.js $NODEJS_VERSION applications" \
@@ -40,7 +43,7 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="${APP_ROOT}/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858" \
+      com.redhat.dev-mode.port="DEBUG_PORT:${DEBUG_PORT}"\
       com.redhat.component="rh-${NAME}${NODEJS_VERSION}-container" \
       name="rhscl/$NAME-$NODEJS_VERSION-rhel7" \
       version="1" \
@@ -53,7 +56,6 @@ RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
     ( [ "rh-${NAME}${NODEJS_VERSION}" != "${NODEJS_SCL}" ] && yum remove -y ${NODEJS_SCL}\* || : ) && \
     INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
-    ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
@@ -64,9 +66,8 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
-    rpm-file-permissions
+# Run further installation commands
+RUN ${CONTAINER_SCRIPTS_PATH}/nodejs_container_install
 
 USER 1001
 

--- a/12/Dockerfile.rhel8
+++ b/12/Dockerfile.rhel8
@@ -20,6 +20,9 @@ ENV NODEJS_VERSION=12 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
+    DEBUG_PORT=5858 \
+    CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/nodejs \
+    NODEJS_PREFIX=/usr \
     PATH=$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:$PATH
 
 ENV SUMMARY="Platform for building and running Node.js $NODEJS_VERSION applications" \
@@ -40,7 +43,7 @@ LABEL summary="$SUMMARY" \
       io.s2i.scripts-url="image:///usr/libexec/s2i" \
       com.redhat.dev-mode="DEV_MODE:false" \
       com.redhat.deployments-dir="${APP_ROOT}/src" \
-      com.redhat.dev-mode.port="DEBUG_PORT:5858" \
+      com.redhat.dev-mode.port="DEBUG_PORT:${DEBUG_PORT}"\
       com.redhat.component="${NAME}-${NODEJS_VERSION}-container" \
       name="ubi8/$NAME-$NODEJS_VERSION" \
       version="1" \
@@ -51,7 +54,6 @@ LABEL summary="$SUMMARY" \
 
 RUN yum -y module reset nodejs && yum -y module enable nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="nodejs npm nodejs-nodemon nss_wrapper" && \
-    ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum remove -y $INSTALL_PKGS && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
@@ -63,9 +65,8 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
-    rpm-file-permissions
+# Run further installation commands
+RUN ${CONTAINER_SCRIPTS_PATH}/nodejs_container_install
 
 USER 1001
 

--- a/12/root/usr/share/container-scripts/nodejs/nodejs_container_install
+++ b/12/root/usr/share/container-scripts/nodejs/nodejs_container_install
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -ex
+
+# Ensure git uses https instead of ssh for NPM install
+# See: https://github.com/npm/npm/issues/5257
+echo -e "Setting git config rules"
+git config --system url."https://github.com".insteadOf git@github.com:
+git config --global url."https://github.com".insteadOf ssh://git@github.com
+git config --system url."https://".insteadOf git://
+git config --system url."https://".insteadOf ssh://
+git config --list
+
+# Since the shebang in the *.js files below is !#/usr/bin/env node, we can
+# just create symlinks and if needed, SCL environment is gonna be enabled properly
+
+# Make sure npx is available on standard path
+if [ ! -h /usr/bin/npx ] ; then
+  ln -s "${NODEJS_PREFIX}/lib/node_modules/npm/bin/npx-cli.js" /usr/bin/npx
+fi
+
+# Make sure nodemon is available on standard path
+if [ ! -h /usr/bin/nodemon ] ; then
+  ln -s "${NODEJS_PREFIX}/lib/node_modules/nodemon/bin/nodemon.js" /usr/bin/nodemon
+fi
+
+# Drop the root user and make the content of /opt/app-root owned by user 1001
+echo "---> Setting directory write permissions"
+fix-permissions "${APP_ROOT}"
+
+# Fix permissions for files installed by RPM
+rpm-file-permissions

--- a/12/root/usr/share/container-scripts/nodejs/nodejs_container_install
+++ b/12/root/usr/share/container-scripts/nodejs/nodejs_container_install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # Ensure git uses https instead of ssh for NPM install
 # See: https://github.com/npm/npm/issues/5257

--- a/12/s2i/bin/assemble
+++ b/12/s2i/bin/assemble
@@ -135,8 +135,11 @@ else
 
 fi
 
-echo "---> Cleaning up npm cache"
-rm -rf .npm
+# TODO: Do we need cache or not actually?
+# based on the following commit, it doesn't seem so:
+# https://github.com/sclorg/s2i-nodejs-container/commit/0e9b5cbb2fe719c447ed3a96fd534f6b2e2ca888
+# echo "---> Cleaning up npm cache"
+# rm -rf .npm
 
 # Fix source directory permissions
 fix-permissions ./

--- a/12/s2i/bin/assemble
+++ b/12/s2i/bin/assemble
@@ -38,6 +38,10 @@ mv /tmp/src/* ./
 # Fix source directory permissions
 fix-permissions ./
 
+if [ "$DEV_MODE" == true ] ; then
+  set -x
+fi
+
 if [ ! -z $HTTP_PROXY ]; then
     echo "---> Setting npm http proxy to" $(safeLogging $HTTP_PROXY)
 	npm config set proxy $HTTP_PROXY
@@ -60,6 +64,7 @@ fi
 
 # Change the npm registry mirror if provided
 if [ -n "$NPM_MIRROR" ]; then
+	echo "---> Setting the npm package mirror to $NPM_MIRROR"
 	npm config set registry $NPM_MIRROR
 fi
 
@@ -78,19 +83,37 @@ if [ -z "$NODE_ENV" ]; then
   fi
 fi
 
-if [ "$NODE_ENV" != "production" ]; then
+echo -e "Current git config"
+git config --list
+
+if [ -n "$YARN_ENABLED" ]; then
+	echo "---> Using 'yarn install' with YARN_ARGS"
+	yarn install $YARN_ARGS
+
+elif [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
 	npm install
 
+	# Do not fail when there is no build script
+	echo "---> Building in development mode"
+	npm run build --if-present
 else
 
-	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+	HAS_BUILD=$(node -e "console.log(require('./package.json').scripts.build ? true : false)")
 
-	#do not fail when there is no build script
-	echo "---> Building in production mode"
-	npm run build --if-present
+	# Check to see if there is a build script by inspecting the package.json
+	if [ "$HAS_BUILD" == true ]; then
+		# Do a npm install to get the dev depdencies
+		echo "---> Installing dev dependencies"
+		NODE_ENV=development npm install
+		# Do not fail when there is no build script
+		echo "---> Building in production mode"
+		npm run build --if-present
+	else
+		echo "---> Using 'npm install -s --only=production'"
+		npm install -s --only=production
+	fi
 
 	echo "---> Pruning the development dependencies"
 	npm prune
@@ -111,6 +134,9 @@ else
 	fi
 
 fi
+
+echo "---> Cleaning up npm cache"
+rm -rf .npm
 
 # Fix source directory permissions
 fix-permissions ./

--- a/12/s2i/bin/run
+++ b/12/s2i/bin/run
@@ -13,25 +13,32 @@ if [ -e "/opt/app-root/etc/generate_container_user" ]; then
   source /opt/app-root/etc/generate_container_user
 fi
 
+export GIT_COMMITTER_NAME="${GIT_COMMITTER_NAME:-unknown}"
+export GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-unknown@localhost.com}"
+git --version
+
 # Runs the nodejs application server. If the container is run in development mode,
 # hot deploy and debugging are enabled.
 run_node() {
   echo -e "Environment: \n\tDEV_MODE=${DEV_MODE}\n\tNODE_ENV=${NODE_ENV}\n\tDEBUG_PORT=${DEBUG_PORT}"
+  echo -e "Running as user $(id)"
   if [ "$DEV_MODE" == true ]; then
+    echo "Installing dev dependencies..."
+    npm install
     echo "Launching via nodemon..."
-    exec nodemon --inspect="$DEBUG_PORT"
+    exec npx nodemon --inspect="$DEBUG_PORT"
   else
     echo "Launching via npm..."
     exec npm run -d $NPM_RUN
   fi
 } 
 
-#Set the debug port to 5858 by default.
+# Set the debug port to 5858 by default.
 if [ -z "$DEBUG_PORT" ]; then
   export DEBUG_PORT=5858
 fi
 
-# Set the environment to development by default.
+# Set the DEV_MODE to false by default.
 if [ -z "$DEV_MODE" ]; then
   export DEV_MODE=false
 fi

--- a/12/s2i/bin/usage
+++ b/12/s2i/bin/usage
@@ -3,12 +3,12 @@
 DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
 
 cat <<EOF
-This is a S2I nodejs-8 ${DISTRO} base image:
+This is a S2I nodejs-${NODEJS_VERSION} ${DISTRO} base image:
 To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-s2i build https://github.com/sclorg/s2i-nodejs-container.git --context-dir=8/test/test-app/ ${NAMESPACE}/nodejs-8-${DISTRO}7 nodejs-sample-app
+s2i build https://github.com/sclorg/s2i-nodejs-container.git --context-dir=${NODEJS_VERSION}/test/test-app/ ${NAMESPACE}/nodejs-${NODEJS_VERSION}-${DISTRO} nodejs-sample-app
 
 You can then run the resulting image via:
 podman run -p 8080:8080 nodejs-sample-app

--- a/test/run
+++ b/test/run
@@ -113,8 +113,8 @@ cleanup() {
 check_result() {
   local result="$1"
   if [[ "$result" != "0" ]]; then
-    echo "S2I image '${IMAGE_NAME}' test FAILED (exit code: ${result})"
     cleanup
+    echo "S2I image '${IMAGE_NAME}' test FAILED (exit code: ${result})"
     exit $result
   fi
 }
@@ -263,8 +263,8 @@ test_incremental_build() {
           check_result 1
       fi
   else
-      first=$(echo "$build_log1" | grep -o -e "added [0-9]* packages" | awk '{ print $2 }')
-      second=$(echo "$build_log2" | grep -o -e "added [0-9]* packages" | awk '{ print $2 }')
+      first=$(echo "$build_log1" | grep -o -e "added [0-9]* package" | awk '{ print $2 }')
+      second=$(echo "$build_log2" | grep -o -e "added [0-9]* package" | awk '{ print $2 }')
       if [ "$first" == "$second" ]; then
           echo "ERROR Incremental build failed: both builds installed $first packages"
           check_result 1


### PR DESCRIPTION
Most notable changes:
 * npx is used for nodemon execution
 * GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL variables are set
 * npm cache is cleared by rm -rf .npm (this is commented out, since we've actually had a test for specifically this, that cache is not removed)
 * npm install is run once more when starting the node
 * run npm run build when a build script is present
 * run yarn if  is set, although we do not ship yarn in our images

As a site-effect, these changes were done:
 * Match also singular in the test_incremental_build
 * Print the overall test result after the cleanup messages, so it is more visible.
 * Use supported fedora 31 for v10 Fedora Dockerfile
 * Move install-time steps to nodejs_container_install file (fixes also a wrong /usr/bin/nodemon symlink in case of SCLs)

More details in the commit messages in particular commits.

<!-- issue-commentator = {"comment-id":"2374228856"} -->