### PR TITLE
Adding ability to run npm ci by default

### DIFF
--- a/10/s2i/bin/assemble
+++ b/10/s2i/bin/assemble
@@ -81,12 +81,30 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
+
+	# We will be using npm CI by default for more information please refer to
+	# https://github.com/sclorg/s2i-nodejs-container/issues/212
+	echo "---> Installing dependencies with npm ci"
+	npm ci || \
+	# npm ci will fail if certain conditions aren't met as mentioned in
+	# https://docs.npmjs.com/cli-commands/ci.html#description
+	echo "---> npm ci failed, installing dependencies with npm install"; \
 	npm install
 
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# We will be using npm CI by default for more information please refer to
+	# https://github.com/sclorg/s2i-nodejs-container/issues/212
+	echo "---> Installing dependencies with npm ci"
+	npm ci || \
+	# npm ci will fail if certain conditions aren't met as mentioned in
+	# https://docs.npmjs.com/cli-commands/ci.html#description
+	echo "---> npm ci failed, installing dependencies with npm install"; \
+	npm install
+
+	NODE_ENV=development
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"

--- a/12/s2i/bin/assemble
+++ b/12/s2i/bin/assemble
@@ -81,12 +81,29 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
-	npm install
 
+	# We will be using npm CI by default for more information please refer to
+	# https://github.com/sclorg/s2i-nodejs-container/issues/212
+	echo "---> Installing dependencies with npm ci"
+	npm ci || \
+	# npm ci will fail if certain conditions aren't met as mentioned in
+	# https://docs.npmjs.com/cli-commands/ci.html#description
+	echo "---> npm ci failed, installing dependencies with npm install"; \
+	npm install
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# We will be using npm CI by default for more information please refer to
+	# https://github.com/sclorg/s2i-nodejs-container/issues/212
+	echo "---> Installing dependencies with npm ci"
+	npm ci || \
+	# npm ci will fail if certain conditions aren't met as mentioned in
+	# https://docs.npmjs.com/cli-commands/ci.html#description
+	echo "---> npm ci failed, installing dependencies with npm install"; \
+	npm install
+
+	NODE_ENV=development
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"


### PR DESCRIPTION
Making `npm ci` to run by default and if it fails for any reason we will run `npm install` as a backup, this will prevent build from failure for developers who doesn't use or update  `package-lock.json`.

This is the one way and another way is to use variable `RUN_NPM_CI` like we use `NODE_ENV`, but that would require existing developers to update their `build_template` and for new developers who are not aware of this env variable won't be able to use this approach.

Please refer below docs for more information:
[npm ci](https://docs.npmjs.com/cli-commands/ci.html)
[npm install](https://docs.npmjs.com/cli-commands/install.html)

#212 
