### PR TITLE
Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/test/run-openshift
+++ b/test/run-openshift
@@ -30,7 +30,6 @@ ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/s2i-nodejs-contain
 ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/nodejs-ex.git" . "Welcome to your Node.js application on OpenShift"
 
 for template in nodejs.json nodejs-mongodb.json nodejs-mongodb-persistent.json ; do
-
   ct_os_test_template_app ${IMAGE_NAME} \
                           https://raw.githubusercontent.com/sclorg/nodejs-ex/${BRANCH_TO_TEST}/openshift/templates/${template} \
                           nodejs \

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -22,15 +22,20 @@ trap ct_os_cleanup EXIT SIGINT
 
 ct_os_check_compulsory_vars
 
-ct_os_enable_print_logs
+oc status || false "It looks like oc is not properly logged in."
 
-ct_os_cluster_up
+export CT_SKIP_NEW_PROJECT=true
+export CT_SKIP_UPLOAD_IMAGE=true
+export CT_NAMESPACE=openshift
+
+test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
+test -n "${VERSION-}" || false 'make sure $VERSION is defined'
+
 # TODO: We can make the tests work against examples inside the same PR
 ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/s2i-nodejs-container.git" test/test-app "This is a node.js echo service"
 ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/nodejs-ex.git" . "Welcome to your Node.js application on OpenShift"
 
 for template in nodejs.json nodejs-mongodb.json nodejs-mongodb-persistent.json ; do
-
   ct_os_test_template_app ${IMAGE_NAME} \
                           https://raw.githubusercontent.com/sclorg/nodejs-ex/${BRANCH_TO_TEST}/openshift/templates/${template} \
                           nodejs \
@@ -42,8 +47,6 @@ done
 test_nodejs_imagestream
 
 OS_TESTSUITE_RESULT=0
-
-ct_os_cluster_down
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Functions for tests for the Node.js image in OpenShift.
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+
+source "${THISDIR}/test-lib.sh"
+source "${THISDIR}/test-lib-openshift.sh"
+
+# Check the imagestream
+function test_nodejs_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_quickstart "${THISDIR}/../imagestreams/nodejs-${OS}.json" \
+                                     "https://raw.githubusercontent.com/sclorg/nodejs-ex/master/openshift/templates/nodejs.json" \
+                                     "${IMAGE_NAME}" \
+                                     'nodejs' \
+                                     "Welcome to your Node.js application on OpenShift" \
+                                     8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p SOURCE_REPOSITORY_URL=https://github.com/sclorg/nodejs-ex.git -p NODEJS_VERSION=${VERSION} -p NAME=nodejs-testing"
+}
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
+


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster