### PR TITLE
Support testing NodeJS container in OpenShift 4 environment

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -48,9 +48,8 @@ for template in nodejs.json nodejs-mongodb.json nodejs-mongodb-persistent.json ;
 done
 
 
-# TODO Suppress test for now
 # Check the imagestream
-#test_nodejs_imagestream
+test_nodejs_imagestream
 
 OS_TESTSUITE_RESULT=0
 

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -11,6 +11,8 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-openshift.sh"
 source "${THISDIR}/test-lib-nodejs.sh"
+source "${THISDIR}/test-lib-remote-openshift.sh"
+
 
 # change the branch to a different value if a new change in the example
 # app needs to be tested
@@ -20,16 +22,18 @@ set -eo nounset
 
 trap ct_os_cleanup EXIT SIGINT
 
+ct_os_set_ocp4
+
 ct_os_check_compulsory_vars
 
 oc status || false "It looks like oc is not properly logged in."
 
-export CT_SKIP_NEW_PROJECT=true
-export CT_SKIP_UPLOAD_IMAGE=true
-export CT_NAMESPACE=openshift
-
 test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
 test -n "${VERSION-}" || false 'make sure $VERSION is defined'
+
+# For testing on OpenShift 4 we use internal registry
+export CT_EXTERNAL_REGISTRY=true
+export CT_SKIP_UPLOAD_IMAGE=true
 
 # TODO: We can make the tests work against examples inside the same PR
 ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/s2i-nodejs-container.git" test/test-app "This is a node.js echo service"
@@ -43,8 +47,10 @@ for template in nodejs.json nodejs-mongodb.json nodejs-mongodb-persistent.json ;
                           8080 http 200 "-p SOURCE_REPOSITORY_REF=${BRANCH_TO_TEST} -p SOURCE_REPOSITORY_URL=https://github.com/sclorg/nodejs-ex.git -p NODEJS_VERSION=${VERSION} -p NAME=nodejs-testing"
 done
 
+
+# TODO Suppress test for now
 # Check the imagestream
-test_nodejs_imagestream
+#test_nodejs_imagestream
 
 OS_TESTSUITE_RESULT=0
 

--- a/test/test-lib-remote-openshift.sh
+++ b/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../common/test-lib-remote-openshift.sh


### PR DESCRIPTION
This commit brings a new functionality for testing SCL images under OpenShift 4.4 environment