### PR TITLE
layer nodejs images on top of s2i-core instead of s2i-base

### DIFF
--- a/10/Dockerfile.fedora
+++ b/10/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f32/s2i-base:latest
+FROM registry.fedoraproject.org/f32/s2i-core:latest
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
@@ -53,7 +53,6 @@ LABEL summary="$SUMMARY" \
 # meanwhile install it during s2i assemble step
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="nodejs npm nss_wrapper" && \
-    yum remove $INSTALL_PKGS -y && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/10/Dockerfile.fedora
+++ b/10/Dockerfile.fedora
@@ -52,7 +52,8 @@ LABEL summary="$SUMMARY" \
 # https://bugzilla.redhat.com/show_bug.cgi?id=1433784
 # meanwhile install it during s2i assemble step
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
-    INSTALL_PKGS="nodejs npm nss_wrapper" && \
+    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    INSTALL_PKGS="$MODULE_DEPS nodejs npm nss_wrapper" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/12/Dockerfile.fedora
+++ b/12/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f32/s2i-base:latest
+FROM registry.fedoraproject.org/f32/s2i-core:latest
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
@@ -50,7 +50,6 @@ LABEL summary="$SUMMARY" \
 
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="nodejs nodejs-nodemon npm nss_wrapper" && \
-    yum remove $INSTALL_PKGS -y && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/12/Dockerfile.fedora
+++ b/12/Dockerfile.fedora
@@ -49,7 +49,8 @@ LABEL summary="$SUMMARY" \
       usage="oc new-app $FGC/$NAME~<SOURCE-REPOSITORY>"
 
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
-    INSTALL_PKGS="nodejs nodejs-nodemon npm nss_wrapper" && \
+    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    INSTALL_PKGS="$MODULE_DEPS nodejs nodejs-nodemon npm nss_wrapper" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -53,7 +53,7 @@ LABEL summary="$SUMMARY" \
       usage="s2i build <SOURCE-REPOSITORY> centos/$NAME-$NODEJS_VERSION-centos7:latest <APP-NAME>"
 
 RUN yum install -y centos-release-scl-rh && \
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    MODULE_DEPS="make gcc gcc-c++" && \
     INSTALL_PKGS="$MODULE_DEPS rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/s2i-base-centos7:1
+FROM centos/s2i-core-centos7:1
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
@@ -53,8 +53,8 @@ LABEL summary="$SUMMARY" \
       usage="s2i build <SOURCE-REPOSITORY> centos/$NAME-$NODEJS_VERSION-centos7:latest <APP-NAME>"
 
 RUN yum install -y centos-release-scl-rh && \
-    ( [ "rh-${NAME}${NODEJS_VERSION}" != "${NODEJS_SCL}" ] && yum remove -y ${NODEJS_SCL}\* || : ) && \
-    INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
+    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    INSTALL_PKGS="$MODULE_DEPS rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/14/Dockerfile.fedora
+++ b/14/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f33/s2i-base:latest
+FROM registry.fedoraproject.org/f33/s2i-core:latest
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
@@ -50,7 +50,6 @@ LABEL summary="$SUMMARY" \
 
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="nodejs nodejs-nodemon npm nss_wrapper" && \
-    yum remove $INSTALL_PKGS -y && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/14/Dockerfile.fedora
+++ b/14/Dockerfile.fedora
@@ -49,7 +49,8 @@ LABEL summary="$SUMMARY" \
       usage="oc new-app $FGC/$NAME~<SOURCE-REPOSITORY>"
 
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
-    INSTALL_PKGS="nodejs nodejs-nodemon npm nss_wrapper" && \
+    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    INSTALL_PKGS="$MODULE_DEPS nodejs nodejs-nodemon npm nss_wrapper" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'

--- a/14/Dockerfile.rhel7
+++ b/14/Dockerfile.rhel7
@@ -57,7 +57,8 @@ LABEL summary="$SUMMARY" \
 
 RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
-    INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
+    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    INSTALL_PKGS="$MODULE_DEPS rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/14/Dockerfile.rhel7
+++ b/14/Dockerfile.rhel7
@@ -57,7 +57,9 @@ LABEL summary="$SUMMARY" \
 
 RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    yum-config-manager --add-repo http://download-node-02.eng.bos.redhat.com/rhel-7/rel-eng/RHSCL-3.6-RHEL-7-Beta-1.0/compose/Server/x86_64/os/ && \
+    echo gpgcheck=0 >> /etc/yum.repos.d/download-node-02.eng.bos.redhat.com_rhel-7_rel-eng_RHSCL-3.6-RHEL-7-Beta-1.0_compose_Server_x86_64_os_.repo && \
+    MODULE_DEPS="make gcc gcc-c++" && \
     INSTALL_PKGS="$MODULE_DEPS rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/14/Dockerfile.rhel7
+++ b/14/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhscl/s2i-base-rhel7:1
+FROM rhscl/s2i-core-rhel7:1
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
@@ -57,7 +57,6 @@ LABEL summary="$SUMMARY" \
 
 RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
-    ( [ "rh-${NAME}${NODEJS_VERSION}" != "${NODEJS_SCL}" ] && yum remove -y ${NODEJS_SCL}\* || : ) && \
     INSTALL_PKGS="rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/14/Dockerfile.rhel8
+++ b/14/Dockerfile.rhel8
@@ -50,7 +50,8 @@ LABEL summary="$SUMMARY" \
       usage="s2i build <SOURCE-REPOSITORY> ubi8/$NAME-$NODEJS_VERSION:latest <APP-NAME>"
 
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
-    INSTALL_PKGS="nodejs npm nodejs-nodemon nss_wrapper" && \
+    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/14/Dockerfile.rhel8
+++ b/14/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM ubi8/s2i-base:1
+FROM ubi8/s2i-core:1
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
@@ -49,10 +49,9 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> ubi8/$NAME-$NODEJS_VERSION:latest <APP-NAME>"
 
-RUN yum -y module reset nodejs && yum -y module enable nodejs:$NODEJS_VERSION && \
+RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="nodejs npm nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
-    yum remove -y $INSTALL_PKGS && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'


### PR DESCRIPTION
As we are installing npm packages in s2i-base that only get
removed during the build of actual nodejs images layered on top,
let us instead build the images directly on top of s2i-core to
preserve some image size.