### PR TITLE
Fix link issue

### DIFF
--- a/test/examples
+++ b/test/examples
@@ -1,0 +1,1 @@
+../examples


### PR DESCRIPTION
This commit fixes issue with the missing examples directory in dist-git.

https://bugzilla.redhat.com/show_bug.cgi?id=1900746#c9

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>