### PR TITLE
Missing git and openssl-devel makes problem in some npm modules

### DIFF
--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -53,7 +53,7 @@ LABEL summary="$SUMMARY" \
       usage="s2i build <SOURCE-REPOSITORY> quay.io/centos7/$NAME-$NODEJS_VERSION-centos7:latest <APP-NAME>"
 
 RUN yum install -y centos-release-scl-rh && \
-    MODULE_DEPS="make gcc gcc-c++" && \
+    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/14/Dockerfile.fedora
+++ b/14/Dockerfile.fedora
@@ -49,7 +49,7 @@ LABEL summary="$SUMMARY" \
       usage="oc new-app $FGC/$NAME~<SOURCE-REPOSITORY>"
 
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs nodejs-nodemon npm nss_wrapper" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/14/Dockerfile.rhel7
+++ b/14/Dockerfile.rhel7
@@ -57,7 +57,7 @@ LABEL summary="$SUMMARY" \
 
 RUN yum install -y yum-utils && \
     prepare-yum-repositories rhel-server-rhscl-7-rpms && \
-    MODULE_DEPS="make gcc gcc-c++" && \
+    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS rh-nodejs${NODEJS_VERSION} rh-nodejs${NODEJS_VERSION}-npm rh-nodejs${NODEJS_VERSION}-nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/14/Dockerfile.rhel8
+++ b/14/Dockerfile.rhel8
@@ -54,7 +54,7 @@ LABEL summary="$SUMMARY" \
       usage="s2i build <SOURCE-REPOSITORY> ubi8/$NAME-$NODEJS_VERSION:latest <APP-NAME>"
 
 RUN yum -y module enable nodejs:$NODEJS_VERSION && \
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops" && \
+    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     ln -s /usr/libexec/platform-python /usr/bin/python3 && \


### PR DESCRIPTION
Originaly reported in https://bugzilla.redhat.com/show_bug.cgi?id=1950018

It was agreed on the Node.js stakeholders meeting that with nodejs minimal
image we don't need to keep the build nodejs 14 container that small any more.