### PR TITLE
chore:  hide ubi7 versions of Node.js.

### DIFF
--- a/imagestreams/nodejs-centos.json
+++ b/imagestreams/nodejs-centos.json
@@ -54,7 +54,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "description": "Build and run Node.js 14 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
           "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
+          "tags": "builder,nodejs,hidden",
           "version": "14",
           "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
@@ -92,7 +92,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "description": "Build and run Node.js 12 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.",
           "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
+          "tags": "builder,nodejs,hidden",
           "version": "12",
           "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },

--- a/imagestreams/nodejs-rhel.json
+++ b/imagestreams/nodejs-rhel.json
@@ -54,7 +54,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "description": "Build and run Node.js 14 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
           "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
+          "tags": "builder,nodejs,hidden",
           "version": "14",
           "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
@@ -92,7 +92,7 @@
           "openshift.io/provider-display-name": "Red Hat, Inc.",
           "description": "Build and run Node.js 12 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.",
           "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
+          "tags": "builder,nodejs,hidden",
           "version": "12",
           "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },


### PR DESCRIPTION
 * This hides the ubi7 versions on Node so they will not appear as options for a user to pick.

 * Motivation:  The drop down list in the Dev Console is showing ubi7 versions of Node before it shows the ubi8.  This seems to be an issue not just for Node.js but for the other runtime options.  Since we(the node team) would like to only promote the use if ubi8(the latest as of this writing), hiding ubi7 from the list the "quick fix" option for the time being"


//cc @yselkowitz 