### PR TITLE
Update imagestreams for RHEL 8.5

### DIFF
--- a/14-minimal/README.md
+++ b/14-minimal/README.md
@@ -34,7 +34,7 @@ The first BuildConfig defines and builds the builder image, using the source-to-
 the `nodejs-builder-image` imagestream.
 
 ```
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: nodejs-builder-image
@@ -59,7 +59,7 @@ from the image and creates a new runtime image on top of the nodejs minimal imag
 The resulting runtime image is then pushed into the `nodejs-runtime-image` imagestream.
 
 ```
-apiVersion: v1
+apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   name: nodejs-runtime-image

--- a/imagestreams/nodejs-centos.json
+++ b/imagestreams/nodejs-centos.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Node.js (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+          "description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "supports":"nodejs",
@@ -22,7 +22,45 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "14-ubi8"
+          "name": "16-ubi8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "16-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 16 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 16 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "16",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/nodejs-16:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "16-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 16 (UBI 8 Minimal)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 16 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "16",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/nodejs-16-minimal:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -52,7 +90,7 @@
         "annotations": {
           "openshift.io/display-name": "Node.js 14 (UBI 8 Minimal)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 14 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+          "description": "Build and run Node.js 14 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14-minimal/README.md.",
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "14",
@@ -99,44 +137,6 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.access.redhat.com/ubi8/nodejs-12:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "12-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 12 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 12 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs,hidden",
-          "version": "12",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi7/nodejs-12:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "12",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 12",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 12 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs,hidden",
-          "version": "12",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "quay.io/centos7/nodejs-12-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nodejs-centos.json
+++ b/imagestreams/nodejs-centos.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "nodejs",
     "annotations": {

--- a/imagestreams/nodejs-rhel-aarch64.json
+++ b/imagestreams/nodejs-rhel-aarch64.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Node.js (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+          "description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "supports":"nodejs",
@@ -22,7 +22,45 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "14-ubi8"
+          "name": "16-ubi8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "16-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 16 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 16 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "16",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-16:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "16-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 16 (UBI 8 Minimal)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 16 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "16",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-16-minimal:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -52,7 +90,7 @@
         "annotations": {
           "openshift.io/display-name": "Node.js 14 (UBI 8 Minimal)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 14 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+          "description": "Build and run Node.js 14 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14-minimal/README.md.",
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "14",

--- a/imagestreams/nodejs-rhel-aarch64.json
+++ b/imagestreams/nodejs-rhel-aarch64.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "nodejs",
     "annotations": {

--- a/imagestreams/nodejs-rhel.json
+++ b/imagestreams/nodejs-rhel.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Node.js (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
+          "description": "Build and run Node.js applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Node.js available on OpenShift, including major version updates.",
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "supports":"nodejs",
@@ -22,7 +22,45 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "14-ubi8"
+          "name": "16-ubi8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "16-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 16 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 16 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "16",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-16:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "16-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 16 (UBI 8 Minimal)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 16 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/16-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "16",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-16-minimal:latest"
         },
         "referencePolicy": {
           "type": "Local"
@@ -52,7 +90,7 @@
         "annotations": {
           "openshift.io/display-name": "Node.js 14 (UBI 8 Minimal)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 14 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14/README.md.",
+          "description": "Build and run Node.js 14 applications on UBI 8 Minimal. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/14-minimal/README.md.",
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
           "version": "14",
@@ -99,44 +137,6 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi8/nodejs-12:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "12-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 12 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 12 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs,hidden",
-          "version": "12",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/nodejs-12:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "12",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 12",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 12 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/12/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs,hidden",
-          "version": "12",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/nodejs-12-rhel7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nodejs-rhel.json
+++ b/imagestreams/nodejs-rhel.json
@@ -1,6 +1,6 @@
 {
   "kind": "ImageStream",
-  "apiVersion": "v1",
+  "apiVersion": "image.openshift.io/v1",
   "metadata": {
     "name": "nodejs",
     "annotations": {


### PR DESCRIPTION
- Update imagestreams for RHEL 8.5
- Use groupified apiVersion

rh-nodejs12 goes out of support in December.
