### PR TITLE
Add GitHub Actions for pushing minimal images to Quay.io

### DIFF
--- a/.github/workflows/build-and-push-minimal.yml
+++ b/.github/workflows/build-and-push-minimal.yml
@@ -1,0 +1,70 @@
+name: Push s2i-nodejs minimal images to Quay.io registry
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push-minimal:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        version: [14-minimal, 16-minimal]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Get base image name
+        id: base-image-name
+        run: |
+          # This command returns row with BASE_IMAGE_NAME
+          row=$(grep "BASE_IMAGE_NAME" Makefile)
+          # Return only base image name
+          BASE_IMAGE_ROW=${row/BASE_IMAGE_NAME = /}
+          echo ::set-output name=image_name::$BASE_IMAGE_ROW
+
+      - name: Get short version
+        id: short_version
+        run: |
+          ver="${{ matrix.version }}"
+          echo "::set-output name=SHORT_VER::${ver//./}"
+
+      - name: Check if Dockerfile.rhel8 is present in version directory
+        id: check_dockerfile_rhel8_file
+        # https://github.com/marketplace/actions/file-existence
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "${{ matrix.version }}/Dockerfile.rhel8"
+
+      - name: Check if .exclude-rhel8 is present in version directory
+        id: check_exclude_rhel8_file
+        # https://github.com/marketplace/actions/file-existence
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "${{ matrix.version }}/.exclude-rhel8"
+
+      - name: Build RHEL8 image
+        if: steps.check_exclude_rhel8_file.outputs.files_exists == 'false' && steps.check_dockerfile_rhel8_file.outputs.files_exists == 'true'
+        id: build-image
+        # https://github.com/marketplace/actions/buildah-build
+        uses: redhat-actions/buildah-build@v2
+        with:
+          dockerfiles: ${{ matrix.version }}/Dockerfile.rhel8
+          image: ${{ steps.base-image-name.outputs.image_name}}-${{ steps.short_version.outputs.SHORT_VER }}
+          tags: el8
+
+      - name: Push RHEL8 image to Quay.io
+        if: steps.check_exclude_rhel8_file.outputs.files_exists == 'false' && steps.check_dockerfile_rhel8_file.outputs.files_exists == 'true'
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2.2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/sclorg
+          username: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_SCLORG_BUILDER_TOKEN }}
+
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
Push 14-minimal and 16-minimal images to Quay.io by each merge request.
Dockerfile.rhel8 has to be present in versions directories.
Otherwise the image is not built

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>