### PR TITLE
This pull request deprecated NodeJS 12 and updates base images

### DIFF
--- a/14/Dockerfile.fedora
+++ b/14/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f33/s2i-core:latest
+FROM registry.fedoraproject.org/f34/s2i-core:latest
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.

--- a/16/Dockerfile.fedora
+++ b/16/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/f33/s2i-core:latest
+FROM registry.fedoraproject.org/f35/s2i-core:latest
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.


### PR DESCRIPTION
This pull request updates NodeJS 14 and NodeJS 16 base images.
NodeJS 12 reached EOL for Fedora case.

Pull request fixes #301 .