### PR TITLE
fix cache cleanup for c9s and rhel9

### DIFF
--- a/14-minimal/s2i/bin/assemble
+++ b/14-minimal/s2i/bin/assemble
@@ -95,6 +95,12 @@ else
 	echo "---> Pruning the development dependencies"
 	npm prune
 
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
 	# Clear the npm's cache and tmp directories only if they are not a docker volumes
 	NPM_CACHE=$(npm config get cache)
 	if ! mountpoint $NPM_CACHE; then
@@ -104,12 +110,6 @@ else
 		# We do not want to delete .npmrc file.
 		rm -rf "${NPM_CACHE:?}/"
 	fi
-	NPM_TMP=$(npm config get tmp)
-	if ! mountpoint $NPM_TMP; then
-		echo "---> Cleaning the $NPM_TMP/npm-*"
-		rm -rf $NPM_TMP/npm-*
-	fi
-
 fi
 
 # Fix source directory permissions

--- a/14/s2i/bin/assemble
+++ b/14/s2i/bin/assemble
@@ -95,6 +95,12 @@ else
 	echo "---> Pruning the development dependencies"
 	npm prune
 
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
 	# Clear the npm's cache and tmp directories only if they are not a docker volumes
 	NPM_CACHE=$(npm config get cache)
 	if ! mountpoint $NPM_CACHE; then
@@ -104,12 +110,6 @@ else
 		# We do not want to delete .npmrc file.
 		rm -rf "${NPM_CACHE:?}/"
 	fi
-	NPM_TMP=$(npm config get tmp)
-	if ! mountpoint $NPM_TMP; then
-		echo "---> Cleaning the $NPM_TMP/npm-*"
-		rm -rf $NPM_TMP/npm-*
-	fi
-
 fi
 
 # Fix source directory permissions

--- a/16/s2i/bin/assemble
+++ b/16/s2i/bin/assemble
@@ -95,6 +95,12 @@ else
 	echo "---> Pruning the development dependencies"
 	npm prune
 
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
 	# Clear the npm's cache and tmp directories only if they are not a docker volumes
 	NPM_CACHE=$(npm config get cache)
 	if ! mountpoint $NPM_CACHE; then
@@ -104,12 +110,6 @@ else
 		# We do not want to delete .npmrc file.
 		rm -rf "${NPM_CACHE:?}/"
 	fi
-	NPM_TMP=$(npm config get tmp)
-	if ! mountpoint $NPM_TMP; then
-		echo "---> Cleaning the $NPM_TMP/npm-*"
-		rm -rf $NPM_TMP/npm-*
-	fi
-
 fi
 
 # Fix source directory permissions

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -446,13 +446,9 @@ function test_nodemon_present() {
 
 function test_npm_cache_cleared() {
   # Test that the npm cache has been cleared
-  # Do not run test on CentOS Stream 9.
-  # The directory container _logs directory.
-  if [ "${OS}" != "c9s" ]; then
-    devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! test -d \$(npm config get cache)")
-    check_result "$?"
-  fi
-
+  cache_loc=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "npm config get cache")
+  devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! test -d $cache_loc")
+  check_result "$?"
 }
 
 function test_npm_cache_exists() {


### PR DESCRIPTION
npm calls are creating log files in the cache, so we need to first
use one container to get cache location and check that it is empty
via a second container