### PR TITLE
test: add kube-service-bindings module to the node module tests

### DIFF
--- a/test/run
+++ b/test/run
@@ -85,8 +85,8 @@ readonly PROMCLIENT_REVISION=v"${PROMCLIENT_REVISION:-$(docker run --rm "${IMAGE
 readonly PROMCLIENT_REPO="https://github.com/siimon/prom-client.git"
 readonly OPOSSUM_REVISION="v${OPOSSUM_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show opossum version)}"
 readonly OPOSSUM_REPO="https://github.com/nodeshift/opossum.git"
-readonly KUBE_SERVICE_BINDINGS_REVISION="v${KUBE_SERVICE_BINDINGS_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show kube-service-bindings version)}"
-readonly KUBE_SERVICE_BINDINGS_REPO="https://github.com/nodeshift/opossum.git"
+readonly KUBESERVICEBINDINGS_REVISION="v${KUBESERVICEBINDINGS_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show kube-service-bindings version)}"
+readonly KUBESERVICEBINDINGS_REPO="https://github.com/nodeshift/kube-service-bindings.git"
 
 source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-nodejs.sh"

--- a/test/run
+++ b/test/run
@@ -73,6 +73,7 @@ express
 pino
 prom-client
 opossum
+kube-service-bindings
 "
 
 CLIENT_LIST=($TEST_LIST_CLIENTS)
@@ -84,6 +85,8 @@ readonly PROMCLIENT_REVISION=v"${PROMCLIENT_REVISION:-$(docker run --rm "${IMAGE
 readonly PROMCLIENT_REPO="https://github.com/siimon/prom-client.git"
 readonly OPOSSUM_REVISION="v${OPOSSUM_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show opossum version)}"
 readonly OPOSSUM_REPO="https://github.com/nodeshift/opossum.git"
+readonly KUBE_SERVICE_BINDINGS_REVISION="v${KUBE_SERVICE_BINDINGS_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show kube-service-bindings version)}"
+readonly KUBE_SERVICE_BINDINGS_REPO="https://github.com/nodeshift/opossum.git"
 
 source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-nodejs.sh"


### PR DESCRIPTION
This adds the kube-service-bindings module to the test suite, so we can add it to the "Tested and Verified" section of the RH node.js product docs