### PR TITLE
Exit oc tests gracefully if login fails

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -25,15 +25,15 @@ test_nodejs_imagestream
 # app needs to be tested
 BRANCH_TO_TEST=master
 
-set -u
-
 trap ct_os_cleanup EXIT SIGINT
 
 ct_os_set_ocp4
 
 ct_os_check_compulsory_vars
 
-oc status || false "It looks like oc is not properly logged in."
+ct_os_check_login || exit 1
+
+set -u
 
 test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
 test -n "${VERSION-}" || false 'make sure $VERSION is defined'


### PR DESCRIPTION

    exit oc4 tests gracefully  if login fails

    The nounset shell option needs to be set after the OC login attempt,
    because (from man shopt):

    -u
      If expansion is attempted on an unset  variable  or
      parameter,  the  shell prints  an  error  message, and, if not
      interactive, exits with a non zero status.

    That is in this matter unconvient, as we do not really know from logs
    what has happened if the oc login fails and moreover the testuite ends
    with success, as only first failed test sets TESTSUITE_RESULT to 1.

    If we check login with ct_os_check_login function, it handles the
    situation conveniently.