### PR TITLE
CVP fixes from container-common-scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Images available on Quay are:
 * CentOS Stream 9 [nodejs-16](https://quay.io/repository/sclorg/nodejs-16-c9s)
 * Fedora [nodejs-14](https://quay.io/repository/fedora/nodejs-14)
 * Fedora [nodejs-16](https://quay.io/repository/fedora/nodejs-16)
+* Fedora [nodejs-18](https://quay.io/repository/fedora/nodejs-18)
 
 This repository contains the source for building various versions of
 the Node.JS application as a reproducible container image using
@@ -97,6 +98,9 @@ see [usage documentation](14/README.md).
 
 For information about usage of Dockerfile for NodeJS 16,
 see [usage documentation](16/README.md).
+
+For information about usage of Dockerfile for NodeJS 18,
+see [usage documentation](18/README.md).
 
 Test
 ----

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -31,6 +31,8 @@ ct_os_set_ocp4
 
 ct_os_check_compulsory_vars
 
+ct_os_tag_image_for_cvp "nodejs"
+
 ct_os_check_login || exit 1
 
 set -u


### PR DESCRIPTION
Also, README.md has to be fixed. Missing Fedora reference to quay.io and new version.