### PR TITLE
Add a test in Dockerfile directly to check nodejs version

### DIFF
--- a/14-minimal/Dockerfile.rhel8
+++ b/14-minimal/Dockerfile.rhel8
@@ -53,6 +53,7 @@ RUN INSTALL_PKGS="nodejs nodejs-nodemon npm findutils tar" && \
     microdnf module disable nodejs && \
     microdnf module enable nodejs:$NODEJS_VERSION && \
     microdnf --nodocs install $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 

--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -58,6 +58,7 @@ RUN yum install -y centos-release-scl-rh && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/14/Dockerfile.fedora
+++ b/14/Dockerfile.fedora
@@ -53,6 +53,7 @@ RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="$MODULE_DEPS nodejs nodejs-nodemon npm nss_wrapper" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/14/Dockerfile.rhel7
+++ b/14/Dockerfile.rhel7
@@ -62,6 +62,7 @@ RUN yum install -y yum-utils && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/14/Dockerfile.rhel8
+++ b/14/Dockerfile.rhel8
@@ -60,6 +60,7 @@ RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     ln -s /usr/libexec/platform-python /usr/bin/python3 && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/16-minimal/Dockerfile.rhel8
+++ b/16-minimal/Dockerfile.rhel8
@@ -54,6 +54,7 @@ RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar" && \
     microdnf module disable nodejs && \
     microdnf module enable nodejs:$NODEJS_VERSION && \
     microdnf --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 

--- a/16-minimal/Dockerfile.rhel9
+++ b/16-minimal/Dockerfile.rhel9
@@ -52,6 +52,7 @@ LABEL summary="$SUMMARY" \
 # nodejs-full-i18n is included for error strings
 RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 

--- a/16/Dockerfile
+++ b/16/Dockerfile
@@ -58,6 +58,7 @@ RUN yum install -y centos-release-scl-rh && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/16/Dockerfile.c9s
+++ b/16/Dockerfile.c9s
@@ -59,6 +59,7 @@ RUN MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/16/Dockerfile.fedora
+++ b/16/Dockerfile.fedora
@@ -53,6 +53,7 @@ RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="$MODULE_DEPS nodejs nodejs-nodemon npm nss_wrapper" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/16/Dockerfile.rhel7
+++ b/16/Dockerfile.rhel7
@@ -62,6 +62,7 @@ RUN yum install -y yum-utils && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/16/Dockerfile.rhel8
+++ b/16/Dockerfile.rhel8
@@ -60,6 +60,7 @@ RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     ln -s /usr/libexec/platform-python /usr/bin/python3 && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/16/Dockerfile.rhel9
+++ b/16/Dockerfile.rhel9
@@ -58,6 +58,7 @@ RUN MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/18-minimal/Dockerfile.c8s
+++ b/18-minimal/Dockerfile.c8s
@@ -54,6 +54,7 @@ RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar" && \
     microdnf module disable nodejs && \
     microdnf module enable nodejs:$NODEJS_VERSION && \
     microdnf --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 

--- a/18-minimal/Dockerfile.c9s
+++ b/18-minimal/Dockerfile.c9s
@@ -52,6 +52,7 @@ LABEL summary="$SUMMARY" \
 # nodejs-full-i18n is included for error strings
 RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 

--- a/18-minimal/Dockerfile.rhel8
+++ b/18-minimal/Dockerfile.rhel8
@@ -54,6 +54,7 @@ RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar" && \
     microdnf module disable nodejs && \
     microdnf module enable nodejs:$NODEJS_VERSION && \
     microdnf --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 

--- a/18-minimal/Dockerfile.rhel9
+++ b/18-minimal/Dockerfile.rhel9
@@ -52,6 +52,7 @@ LABEL summary="$SUMMARY" \
 # nodejs-full-i18n is included for error strings
 RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 

--- a/18/Dockerfile.c8s
+++ b/18/Dockerfile.c8s
@@ -60,6 +60,7 @@ RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     ln -s /usr/libexec/platform-python /usr/bin/python3 && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/18/Dockerfile.c9s
+++ b/18/Dockerfile.c9s
@@ -59,6 +59,7 @@ RUN MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/18/Dockerfile.fedora
+++ b/18/Dockerfile.fedora
@@ -53,6 +53,7 @@ RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     INSTALL_PKGS="$MODULE_DEPS nodejs nodejs-nodemon npm nss_wrapper-libs" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/18/Dockerfile.rhel8
+++ b/18/Dockerfile.rhel8
@@ -60,6 +60,7 @@ RUN yum -y module enable nodejs:$NODEJS_VERSION && \
     ln -s /usr/libexec/platform-python /usr/bin/python3 && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH

--- a/18/Dockerfile.rhel9
+++ b/18/Dockerfile.rhel9
@@ -58,6 +58,7 @@ RUN MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
+    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     yum -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH


### PR DESCRIPTION
Otherwise when a wrong stream is installed, it's only found by scl test,
which is too late in the process and might even go through uncought,
especially when the scl test is removed for non-SCL distros at some point.