### PR TITLE
fix: specifying nodejs version to be on 18

### DIFF
--- a/18-minimal/Dockerfile.rhel9
+++ b/18-minimal/Dockerfile.rhel9
@@ -51,6 +51,8 @@ LABEL summary="$SUMMARY" \
 
 # nodejs-full-i18n is included for error strings
 RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar" && \
+    microdnf module disable nodejs && \
+    microdnf module enable nodejs:$NODEJS_VERSION && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     microdnf clean all && \

--- a/18/Dockerfile.c9s
+++ b/18/Dockerfile.c9s
@@ -54,7 +54,8 @@ LABEL summary="$SUMMARY" \
       usage="s2i build <SOURCE-REPOSITORY> quay.io/sclorg/$NAME-$NODEJS_VERSION-c9s:latest <APP-NAME>"
 
 # Package libatomic_ops was removed
-RUN MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
+RUN yum -y module enable nodejs:$NODEJS_VERSION && \
+    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \

--- a/18/Dockerfile.rhel9
+++ b/18/Dockerfile.rhel9
@@ -53,7 +53,8 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> ubi9/$NAME-$NODEJS_VERSION:latest <APP-NAME>"
 
-RUN MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
+RUN yum -y module enable nodejs:$NODEJS_VERSION && \
+    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \


### PR DESCRIPTION
This fix, specifies nodejs version to be on 18, otherwise the build image does not build as described on this issue https://github.com/sclorg/s2i-nodejs-container/issues/357