### PR TITLE
chore: Add the fastify to the testing suite.

### DIFF
--- a/test/run
+++ b/test/run
@@ -74,6 +74,7 @@ test_client_prom
 test_client_opossum
 test_client_kube
 test_client_faas
+test_client_fastify
 "
 
 # If an app or a test is in UNSTABLE_TESTS and IGNORE_UNSTABLE_TESTS
@@ -99,6 +100,8 @@ readonly KUBESERVICEBINDINGS_REVISION="v${KUBESERVICEBINDINGS_REVISION:-$(docker
 readonly KUBESERVICEBINDINGS_REPO="https://github.com/nodeshift/kube-service-bindings.git"
 readonly FAASJSRUNTIME_REVISION="v${FAASJSRUNTIME_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show faas-js-runtime version)}"
 readonly FAASJSRUNTIME_REPO="https://github.com/nodeshift/faas-js-runtime.git"
+readonly FASTIFY_REVISION="v${FASTIFY_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show fastify version)}"
+readonly FASTIFY_REPO="https://github.com/fastify/fastify.git"
 
 source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-nodejs.sh"

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -414,6 +414,11 @@ function test_client_faas() {
   test_running_client_js faas-js-runtime
 }
 
+function test_client_fastify() {
+  echo "Running fastify client test"
+  test_running_client_js fastify
+}
+
 function test_check_build_using_dockerfile() {
   info "Check building using a Dockerfile"
   ct_test_app_dockerfile ${THISDIR}/examples/from-dockerfile/Dockerfile 'https://github.com/sclorg/nodejs-ex.git' 'Welcome to your Node.js application on OpenShift' app-src


### PR DESCRIPTION
Fastify is a major part of the faas-js-runtime and is responsible for invoking and hosting the node.js serverless functions on Openshift.