### PR TITLE
chore: Add the cloudevents client to the testing suite.

### DIFF
--- a/test/run
+++ b/test/run
@@ -74,6 +74,7 @@ test_client_prom
 test_client_opossum
 test_client_kube
 test_client_faas
+test_client_cloudevents
 "
 
 # If an app or a test is in UNSTABLE_TESTS and IGNORE_UNSTABLE_TESTS
@@ -99,6 +100,8 @@ readonly KUBESERVICEBINDINGS_REVISION="v${KUBESERVICEBINDINGS_REVISION:-$(docker
 readonly KUBESERVICEBINDINGS_REPO="https://github.com/nodeshift/kube-service-bindings.git"
 readonly FAASJSRUNTIME_REVISION="v${FAASJSRUNTIME_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show faas-js-runtime version)}"
 readonly FAASJSRUNTIME_REPO="https://github.com/nodeshift/faas-js-runtime.git"
+readonly CLOUDEVENTS_REVISION="v${CLOUDEVENTS_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show cloudevents version)}"
+readonly CLOUDEVENTS_REPO="https://github.com/cloudevents/sdk-javascript.git"
 
 source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-nodejs.sh"

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -414,6 +414,11 @@ function test_client_faas() {
   test_running_client_js faas-js-runtime
 }
 
+function test_client_cloudevents() {
+  echo "Running CloudEvents client test"
+  test_running_client_js cloudevents
+}
+
 function test_check_build_using_dockerfile() {
   info "Check building using a Dockerfile"
   ct_test_app_dockerfile ${THISDIR}/examples/from-dockerfile/Dockerfile 'https://github.com/sclorg/nodejs-ex.git' 'Welcome to your Node.js application on OpenShift' app-src


### PR DESCRIPTION
The cloudevents sdk is a major part of the faas-js-runtime and is responsible for converting the requests events into CloudEvents.