### PR TITLE
chore: removes pino temporarily from testing

### DIFF
--- a/test/run
+++ b/test/run
@@ -70,7 +70,6 @@ test_build_express_webapp
 # XXX_REVISION and XXX_REPO must be defined below
 TEST_LIST_CLIENTS="\
 test_client_express
-test_client_pino
 test_client_prom
 test_client_opossum
 test_client_kube
@@ -86,7 +85,7 @@ test_client_faas
 #     - the upstream testcase nondeterministically fails.
 #       Bug on upstream is already issued. We were not able to find a reproducer
 #       for this yet. See https://github.com/pinojs/pino/issues/1252.
-declare -a UNSTABLE_TESTS=(test_client_pino)
+## declare -a UNSTABLE_TESTS=(test_client_pino)
 
 readonly EXPRESS_REVISION="${EXPRESS_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show express version)}"
 readonly EXPRESS_REPO="https://github.com/expressjs/express.git"


### PR DESCRIPTION
Based on our conversations regarding the flaky pino tests, this PR is for temporarily removing the module from testing.

One of the issue that is happening is being worked on in the upstream repo:  https://github.com/pinojs/pino/pull/1691. It looks like they have also found some timeout issues, which we've seen here, which look like it might be a couple weeks before those issues get looked at:  https://github.com/pinojs/pino/pull/1691#issuecomment-1518552096

