### PR TITLE
use ct_init in test/run for minimal images

### DIFF
--- a/test/run-minimal
+++ b/test/run-minimal
@@ -55,7 +55,6 @@ test_run_hw_application
 source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-nodejs.sh"
 
-ct_enable_cleanup
 
 test -n $IMAGE_NAME \
   -a -n $VERSION
@@ -63,9 +62,6 @@ readonly EXPRESS_REVISION="${EXPRESS_REVISION:-$(docker run --rm "${IMAGE_NAME}"
 
 test_dir="$(readlink -f $(dirname ${BASH_SOURCE[0]}))"
 image_dir="$(readlink -f ${test_dir}/..)"
-
-CID_FILE_DIR=$(mktemp -d)
-cid_file=$CID_FILE_DIR/$(mktemp -u -p . --suffix=.cid)
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -86,7 +82,8 @@ if [ "$DEBUG" != "" ]; then
   set -x
 fi
 
-TEST_SUMMARY=""
+ct_init
+cid_file=$CID_FILE_DIR/$(mktemp -u -p . --suffix=.cid)
 
 # Build the application image twice to ensure the 'save-artifacts' and
 # 'restore-artifacts' scripts are working properly


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
`test/run` has already been updated with `ct_init` function. In order to run test correctly the `run-minimal` needs to be updated too.