### PR TITLE
Build and push Fedora NodeJS-18 minimal to quay.io

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -63,6 +63,13 @@ jobs:
             quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
             image_name: "nodejs-18"
+          - dockerfile: "18-minimal/Dockerfile.fedora"
+            docker_context: 18-minimal
+            registry_namespace: "fedora"
+            tag: "fedora"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            image_name: "nodejs-18-minimal"
           - dockerfile: "20/Dockerfile.fedora"
             docker_context: 20
             registry_namespace: "fedora"


### PR DESCRIPTION
This pull request builds and pushes NodeJS-18 minimal container image to quay.io.

Repository on quay.io is already prepared. See https://quay.io/repository/fedora/nodejs-18-minimal?tab=info
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
