### PR TITLE
Add NPM_BUILD environment variable

### DIFF
--- a/14-minimal/README.md
+++ b/14-minimal/README.md
@@ -209,6 +209,9 @@ Application developers can use the following environment variables to configure 
 **`DEV_MODE`**  
        When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
 
+**`NPM_BUILD`**  
+       Select an alternate / custom build command, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "build"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
 **`NPM_RUN`**  
        Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
 

--- a/14-minimal/s2i/bin/assemble
+++ b/14-minimal/s2i/bin/assemble
@@ -90,7 +90,7 @@ else
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"
-	npm run build --if-present
+	npm run ${NPM_BUILD:-build} --if-present
 
 	echo "---> Pruning the development dependencies"
 	npm prune

--- a/14/README.md
+++ b/14/README.md
@@ -139,6 +139,9 @@ Application developers can use the following environment variables to configure 
 **`DEV_MODE`**  
        When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
 
+**`NPM_BUILD`**  
+       Select an alternate / custom build command, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "build"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
 **`NPM_RUN`**  
        Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
 

--- a/14/s2i/bin/assemble
+++ b/14/s2i/bin/assemble
@@ -90,7 +90,7 @@ else
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"
-	npm run build --if-present
+	npm run ${NPM_BUILD:-build} --if-present
 
 	echo "---> Pruning the development dependencies"
 	npm prune

--- a/16-minimal/README.md
+++ b/16-minimal/README.md
@@ -209,6 +209,9 @@ Application developers can use the following environment variables to configure 
 **`DEV_MODE`**  
        When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
 
+**`NPM_BUILD`**  
+       Select an alternate / custom build command, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "build"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
 **`NPM_RUN`**  
        Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
 

--- a/16-minimal/s2i/bin/assemble
+++ b/16-minimal/s2i/bin/assemble
@@ -90,7 +90,7 @@ else
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"
-	npm run build --if-present
+	npm run ${NPM_BUILD:-build} --if-present
 
 	echo "---> Pruning the development dependencies"
 	npm prune

--- a/16/README.md
+++ b/16/README.md
@@ -139,6 +139,9 @@ Application developers can use the following environment variables to configure 
 **`DEV_MODE`**  
        When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
 
+**`NPM_BUILD`**  
+       Select an alternate / custom build command, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "build"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
 **`NPM_RUN`**  
        Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
 

--- a/16/s2i/bin/assemble
+++ b/16/s2i/bin/assemble
@@ -90,7 +90,7 @@ else
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"
-	npm run build --if-present
+	npm run ${NPM_BUILD:-build} --if-present
 
 	echo "---> Pruning the development dependencies"
 	npm prune

--- a/18-minimal/README.md
+++ b/18-minimal/README.md
@@ -209,6 +209,9 @@ Application developers can use the following environment variables to configure 
 **`DEV_MODE`**  
        When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
 
+**`NPM_BUILD`**  
+       Select an alternate / custom build command, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "build"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
 **`NPM_RUN`**  
        Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
 

--- a/18-minimal/s2i/bin/assemble
+++ b/18-minimal/s2i/bin/assemble
@@ -90,7 +90,7 @@ else
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"
-	npm run build --if-present
+	npm run ${NPM_BUILD:-build} --if-present
 
 	echo "---> Pruning the development dependencies"
 	npm prune

--- a/18/README.md
+++ b/18/README.md
@@ -139,6 +139,9 @@ Application developers can use the following environment variables to configure 
 **`DEV_MODE`**  
        When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
 
+**`NPM_BUILD`**  
+       Select an alternate / custom build command, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "build"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
 **`NPM_RUN`**  
        Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
 

--- a/18/s2i/bin/assemble
+++ b/18/s2i/bin/assemble
@@ -90,7 +90,7 @@ else
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"
-	npm run build --if-present
+	npm run ${NPM_BUILD:-build} --if-present
 
 	echo "---> Pruning the development dependencies"
 	npm prune

--- a/20-minimal/README.md
+++ b/20-minimal/README.md
@@ -209,6 +209,9 @@ Application developers can use the following environment variables to configure 
 **`DEV_MODE`**  
        When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
 
+**`NPM_BUILD`**  
+       Select an alternate / custom build command, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "build"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
 **`NPM_RUN`**  
        Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
 

--- a/20-minimal/s2i/bin/assemble
+++ b/20-minimal/s2i/bin/assemble
@@ -90,7 +90,7 @@ else
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"
-	npm run build --if-present
+	npm run ${NPM_BUILD:-build} --if-present
 
 	echo "---> Pruning the development dependencies"
 	npm prune

--- a/20/README.md
+++ b/20/README.md
@@ -139,6 +139,9 @@ Application developers can use the following environment variables to configure 
 **`DEV_MODE`**  
        When set to "true", `nodemon` will be used to automatically reload the server while you work (default: "false"). Setting `DEV_MODE` to "true" will change the `NODE_ENV` default to "development" (if not explicitly set).
 
+**`NPM_BUILD`**  
+       Select an alternate / custom build command, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "build"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
+
 **`NPM_RUN`**  
        Select an alternate / custom runtime mode, defined in your `package.json` file's [`scripts`](https://docs.npmjs.com/misc/scripts) section (default: npm run "start"). These user-defined run-scripts are unavailable while `DEV_MODE` is in use.
 

--- a/20/s2i/bin/assemble
+++ b/20/s2i/bin/assemble
@@ -90,7 +90,7 @@ else
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"
-	npm run build --if-present
+	npm run ${NPM_BUILD:-build} --if-present
 
 	echo "---> Pruning the development dependencies"
 	npm prune


### PR DESCRIPTION
I would like to be able to specify the npm script for the build step instead of `build`, the same way you can use `NPM_RUN` to specify a different run script instead of `start`. My use case is that I want to build and deploy part of a monorepo. As it is, I have to copy the whole `assemble` file to my `.s2i` directory and change it in there.

I agree with the suggestion in issue #308 that the most appropriate name for this variable would be `NPM_BUILD`. I have not found anything online that would indicate that it is already in use for something else.