### PR TITLE
Add support for ulimit into client part

### DIFF
--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -53,7 +53,7 @@ run_s2i_build_client() {
   ct_s2i_build_as_df \
     "file://${test_dir}/$1" "${IMAGE_NAME}" "${IMAGE_NAME}-$1" \
     ${s2i_args} \
-    $(ct_build_s2i_npm_variables) -e NODE_ENV=development
+    $(ct_build_s2i_npm_variables) -e NODE_ENV=development --ulimit nofile=4096:4096
 }
 
 run_s2i_build_binary() {

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -50,10 +50,10 @@ run_s2i_build_proxy() {
 }
 
 run_s2i_build_client() {
-  ct_s2i_build_as_df \
-    "file://${test_dir}/$1" "${IMAGE_NAME}" "${IMAGE_NAME}-$1" \
+  ct_s2i_build_as_df_build_args \
+    "file://${test_dir}/$1" "${IMAGE_NAME}" "${IMAGE_NAME}-$1" "--ulimit nofile=4096:4096" \
     ${s2i_args} \
-    $(ct_build_s2i_npm_variables) -e NODE_ENV=development --ulimit nofile=4096:4096
+    $(ct_build_s2i_npm_variables) -e NODE_ENV=development
 }
 
 run_s2i_build_binary() {


### PR DESCRIPTION
nodejs container already support ulimit to function `ct_test_app_dockerfile` that is used by most tests.

But client part uses function `ct_s2i_build_as_df` function and we need to enhance it.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
