### PR TITLE
Do not check fastify in case of nodej-18 and RHEL8, RHEL9

### DIFF
--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -420,6 +420,15 @@ function test_client_cloudevents() {
   test_running_client_js cloudevents
 }
 function test_client_fastify() {
+  if [[ "${VERSION}" == *"minimal"* ]]; then
+    VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)
+  fi
+  if [[ "$VERSION" == "18" ]]; then
+    if [ "$OS" == "rhel8" ] || [ "$OS" == "rhel9" ]; then
+      echo "Fastify is not supported in $VERSION and rhel8 and rhel9"
+      return
+    fi
+  fi
   echo "Running fastify client test"
   test_running_client_js fastify
 }


### PR DESCRIPTION
This pull request disabled testing `fastify` on nodejs-18 for RHEL8, and RHEL9.


<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
