### PR TITLE
Check whether build passes. Do not reuse builds across tests.

### DIFF
--- a/test/run
+++ b/test/run
@@ -91,6 +91,41 @@ readonly -A gitconfig=(
 
 [[ -n "$DEBUG" ]] && set -x
 
+# Positive test & non-zero exit status = ERROR.
+# Negative test & zero exit status = ERROR.
+# Tests with '-should-fail-' in their name should fail during a build,
+# expecting non-zero exit status.
+evaluate_build_result() {
+  local _result="$1"
+  local _app="$2"
+  local _type="positive"
+  local _test_msg="[PASSED]"
+  local _ret_code=0
+
+  if [[ "$_app" == *"-should-fail-"* ]]; then
+    _type="negative"
+  fi
+
+  if [[ "$_type" == "positive" && "$_result" != "0" ]]; then
+    info "TEST FAILED (${_type}), EXPECTED:0 GOT:${_result}"
+    _ret_code=$_result
+  elif [[ "$_type" == "negative" && "$_result" == "0" ]]; then
+    info "TEST FAILED (${_type}), EXPECTED: non-zero GOT:${_result}"
+    _ret_code=1
+  fi
+  if [ $_ret_code != 0 ]; then
+    cleanup
+    TESTSUITE_RESULT=1
+    _test_msg="[FAILED]"
+  fi
+  ct_update_test_result "$_test_msg" "$_app" run_s2i_build
+
+  if [[ "$_type" == "negative" && "$_result" != "0" ]]; then
+    _ret_code=127 # even though this is success, the app is still not built
+  fi
+  return $_ret_code
+}
+
 ct_init
 cid_file=$CID_FILE_DIR/$(mktemp -u -p . --suffix=.cid)
 
@@ -100,27 +135,32 @@ prepare app
 check_prep_result $? app || exit
 echo "Testing the production image build"
 run_s2i_build
-ct_check_testcase_result $?
+evaluate_build_result $? "default"
 
 TEST_SET=${TESTS:-$TEST_LIST_APP} ct_run_tests_from_testset "app"
 
-echo "Testing the development image build: s2i build -e \"NODE_ENV=development\")"
+cleanup
+
 run_s2i_build "-e NODE_ENV=development"
-ct_check_testcase_result $?
+evaluate_build_result $? "-e NODE_ENV=development"
 
 TEST_SET=${TESTS:-$TEST_LIST_NODE_ENV} ct_run_tests_from_testset "node_env_development"
 
+cleanup
+
 echo "Testing the development image build: s2i build -e \"DEV_MODE=true\")"
 run_s2i_build "-e DEV_MODE=true"
-ct_check_testcase_result $?
+evaluate_build_result $? "-e DEV_MODE=true"
 
 TEST_SET=${TESTS:-$TEST_LIST_DEV_MODE} ct_run_tests_from_testset "dev_mode"
+
+cleanup
 
 echo "Testing proxy safe logging..."
 prepare hw
 check_prep_result $? hw || exit
 run_s2i_build_proxy http://user.password@0.0.0.0:8000 https://user.password@0.0.0.0:8000 > /tmp/build-log 2>&1
-ct_check_testcase_result $?
+evaluate_build_result $? "proxy"
 
 TEST_SET=${TESTS:-$TEST_LIST_HW} ct_run_tests_from_testset "hw"
 
@@ -134,4 +174,6 @@ if [[ "$VERSION" != "18" ]]; then
   #npm ERR! gyp ERR! node-gyp -v v10.0.1
   #npm ERR! gyp ERR! not ok
   TEST_SET=${TESTS:-$TEST_LIST_BINARY} ct_run_tests_from_testset "binary"
+  
+  cleanup
 fi

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -186,7 +186,7 @@ run_client_test_suite() {
 }
 
 kill_test_application() {
-	docker kill $(cat $cid_file)
+	docker stop $(cat $cid_file)
 	rm $cid_file
 }
 
@@ -686,6 +686,13 @@ function test_latest_imagestreams() {
   result=$?
   popd >/dev/null || return 1
   return $result
+}
+
+function cleanup() {
+  info "Cleaning up the test application image ${IMAGE_NAME}-testapp"
+  if image_exists ${IMAGE_NAME}-testapp; then
+    docker rmi -f ${IMAGE_NAME}-testapp
+  fi
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
Fixes: #444

This contains the same change as in ruby container PR https://github.com/sclorg/s2i-ruby-container/pull/556.

The other change is related to ruby container issue https://github.com/sclorg/s2i-ruby-container/issues/557.

Ruby container issue has a more thorough description on what's specifically the problem.

Reason why `docker kill` has to be changed to `docker stop` in `test/test-lib-nodejs.sh` L: 176 is that `docker kill` doesn't wait for the container to stop. It forcefully kills it and continues. This then creates a race condition with the clearing function. When the `docker rmi -f` is called, the previous kill call hasn't stopped the container fully yet, so the `docker rmi -f` will see the existing container. It will try to delete it, because we are forcing image deletion, but before it goes through the internal process the container gets stopped and deleted by the previous `docker kill` call.

When the `docker rmi -f` actually reaches the part where it wants to delete the container, it doesn't exist anymore and fails. `docker stop` on the other hand won't work asynchronously and will try to gracefully stop the container and in case it doesn't respond it will forcefully kill and continue only after the successful kill happened.

<!-- issue-commentator = {"comment-id":"2374228891"} -->











































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2376604750","data":[{"id":"d1586df1-36d6-46e7-92a6-20c6fa86bcbb","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":1174.339007,"created":"2024-09-30T10:01:51.354063","updated":"2024-09-30T10:01:51.354070","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d1586df1-36d6-46e7-92a6-20c6fa86bcbb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d1586df1-36d6-46e7-92a6-20c6fa86bcbb/pipeline.log\">pipeline</a>"]},{"id":"bab7b7ff-0f33-46ef-a710-ebd58cfd5713","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":621.186323,"created":"2024-09-30T10:02:15.966193","updated":"2024-09-30T10:02:15.966205","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bab7b7ff-0f33-46ef-a710-ebd58cfd5713\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bab7b7ff-0f33-46ef-a710-ebd58cfd5713/pipeline.log\">pipeline</a>"]},{"id":"ed067ada-7922-476d-9baf-6aedc089f5d6","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":1203.200966,"created":"2024-09-30T10:01:48.056072","updated":"2024-09-30T10:01:48.056079","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ed067ada-7922-476d-9baf-6aedc089f5d6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ed067ada-7922-476d-9baf-6aedc089f5d6/pipeline.log\">pipeline</a>"]},{"id":"14df2a6a-18c3-4f2c-9f76-fd74a003c464","name":"Fedora - 18-minimal","status":"complete","outcome":"passed","runTime":640.364082,"created":"2024-09-30T10:01:51.068344","updated":"2024-09-30T10:01:51.068351","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/14df2a6a-18c3-4f2c-9f76-fd74a003c464\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/14df2a6a-18c3-4f2c-9f76-fd74a003c464/pipeline.log\">pipeline</a>"]},{"id":"48eb53d9-4e28-4309-9e96-7548086a09cd","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":724.888216,"created":"2024-09-30T10:01:59.429188","updated":"2024-09-30T10:01:59.429195","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/48eb53d9-4e28-4309-9e96-7548086a09cd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/48eb53d9-4e28-4309-9e96-7548086a09cd/pipeline.log\">pipeline</a>"]},{"id":"14911b95-8584-4e4a-a63a-dcd966189522","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1597.534137,"created":"2024-09-30T10:01:49.855861","updated":"2024-09-30T10:01:49.855871","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/14911b95-8584-4e4a-a63a-dcd966189522\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/14911b95-8584-4e4a-a63a-dcd966189522/pipeline.log\">pipeline</a>"]},{"id":"31550683-8d9c-4e35-accd-7032f60bb6b4","name":"RHEL9 - 18-minimal","status":"complete","outcome":"passed","runTime":876.585201,"created":"2024-09-30T10:01:49.160727","updated":"2024-09-30T10:01:49.160736","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/31550683-8d9c-4e35-accd-7032f60bb6b4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/31550683-8d9c-4e35-accd-7032f60bb6b4/pipeline.log\">pipeline</a>"]},{"id":"7780520f-c63e-4b5b-91c0-cff4cec799e7","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":926.410167,"created":"2024-09-30T10:02:31.817618","updated":"2024-09-30T10:02:31.817626","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7780520f-c63e-4b5b-91c0-cff4cec799e7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7780520f-c63e-4b5b-91c0-cff4cec799e7/pipeline.log\">pipeline</a>"]},{"id":"eb6c3969-26ea-4657-a455-caf4f263e7cc","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":1192.418024,"created":"2024-09-30T10:01:48.664863","updated":"2024-09-30T10:01:48.664870","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb6c3969-26ea-4657-a455-caf4f263e7cc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb6c3969-26ea-4657-a455-caf4f263e7cc/pipeline.log\">pipeline</a>"]},{"id":"3773025d-adc8-4585-98e6-98f29385c878","name":"RHEL8 - 20-minimal","runTime":1795.869833,"created":"2024-09-30T10:01:51.617232","updated":"2024-09-30T10:01:51.617240","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3773025d-adc8-4585-98e6-98f29385c878\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3773025d-adc8-4585-98e6-98f29385c878/pipeline.log\">pipeline</a>"]},{"id":"a203f174-7572-41bd-ada6-8373cb7e25e4","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":819.251808,"created":"2024-09-30T10:01:59.387077","updated":"2024-09-30T10:01:59.387088","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a203f174-7572-41bd-ada6-8373cb7e25e4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a203f174-7572-41bd-ada6-8373cb7e25e4/pipeline.log\">pipeline</a>"]},{"id":"882ae27e-5892-4541-9345-be1216b27656","name":"CentOS Stream 10 - 22","status":"complete","outcome":"failed","runTime":797.179594,"created":"2024-09-30T10:02:01.084640","updated":"2024-09-30T10:02:01.084649","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/882ae27e-5892-4541-9345-be1216b27656\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/882ae27e-5892-4541-9345-be1216b27656/pipeline.log\">pipeline</a>"]},{"id":"dd73da42-fa65-4d55-ba27-fbc563723e92","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":1007.771423,"created":"2024-09-30T10:01:50.426281","updated":"2024-09-30T10:01:50.426289","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/dd73da42-fa65-4d55-ba27-fbc563723e92\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/dd73da42-fa65-4d55-ba27-fbc563723e92/pipeline.log\">pipeline</a>"]},{"id":"1a854409-4569-45f8-b798-aa061a26e8ef","name":"Fedora - 18","status":"complete","outcome":"passed","runTime":899.800027,"created":"2024-09-30T10:01:46.939925","updated":"2024-09-30T10:01:46.939932","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1a854409-4569-45f8-b798-aa061a26e8ef\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1a854409-4569-45f8-b798-aa061a26e8ef/pipeline.log\">pipeline</a>"]},{"id":"138e08d4-8d64-4743-9fdf-074e384e3427","name":"RHEL9 - 18","status":"complete","outcome":"passed","runTime":1081.309967,"created":"2024-09-30T10:01:46.698241","updated":"2024-09-30T10:01:46.698249","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/138e08d4-8d64-4743-9fdf-074e384e3427\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/138e08d4-8d64-4743-9fdf-074e384e3427/pipeline.log\">pipeline</a>"]},{"id":"026f5d6e-0414-439c-ba1b-c4e6f8e30d1e","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1129.408314,"created":"2024-09-30T10:01:49.814596","updated":"2024-09-30T10:01:49.814604","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/026f5d6e-0414-439c-ba1b-c4e6f8e30d1e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/026f5d6e-0414-439c-ba1b-c4e6f8e30d1e/pipeline.log\">pipeline</a>"]},{"id":"021fc666-b02c-446b-a00f-26c79eb49c39","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1186.598958,"created":"2024-09-30T10:02:03.509602","updated":"2024-09-30T10:02:03.509610","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/021fc666-b02c-446b-a00f-26c79eb49c39\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/021fc666-b02c-446b-a00f-26c79eb49c39/pipeline.log\">pipeline</a>"]},{"id":"a10d870b-83aa-4a2a-ac74-98466d901254","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1465.401497,"created":"2024-09-30T10:01:52.052999","updated":"2024-09-30T10:01:52.053006","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a10d870b-83aa-4a2a-ac74-98466d901254\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a10d870b-83aa-4a2a-ac74-98466d901254/pipeline.log\">pipeline</a>"]},{"id":"798fa90d-619c-4a46-b619-1187c608447a","name":"RHEL8 - 18","status":"complete","outcome":"passed","runTime":1250.871831,"created":"2024-09-30T10:01:46.941528","updated":"2024-09-30T10:01:46.941537","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/798fa90d-619c-4a46-b619-1187c608447a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/798fa90d-619c-4a46-b619-1187c608447a/pipeline.log\">pipeline</a>"]},{"id":"797ff004-f0a1-4ccf-9935-d1dfc521e0c1","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":936.549495,"created":"2024-09-30T10:01:50.380497","updated":"2024-09-30T10:01:50.380505","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/797ff004-f0a1-4ccf-9935-d1dfc521e0c1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/797ff004-f0a1-4ccf-9935-d1dfc521e0c1/pipeline.log\">pipeline</a>"]}]} -->