### PR TITLE
Do not tests 22 / 22-minimal in OpenShift 4

### DIFF
--- a/14-minimal/test/run-openshift
+++ b/14-minimal/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/16-minimal/test/run-openshift
+++ b/16-minimal/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/18-minimal/test/run-openshift
+++ b/18-minimal/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/22-minimal/test/run-openshift
+++ b/22-minimal/test/run-openshift
@@ -1,1 +1,0 @@
-../../test/run-openshift

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -46,6 +46,11 @@ test -n "${VERSION-}" || false 'make sure $VERSION is defined'
 export CT_OCP4_TEST=true
 export CT_SKIP_UPLOAD_IMAGE=true
 
+# TODO VERSION 22 is not supported at all
+if [ "${VERSION}" == "22" ] || [ "${VERSION}" == "22-minimal" ]; then
+  exit 0
+fi
+
 TEST_SUMMARY=''
 TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "openshift-remote-cluster"
 

--- a/test/test_helm_nodejs_application.py
+++ b/test/test_helm_nodejs_application.py
@@ -39,6 +39,9 @@ class TestHelmNodeJSApplication:
         self.hc_api.delete_project()
 
     def test_curl_connection(self):
+        # TODO VERSION 22 is not supported at all
+        if VERSION.startswith("22"):
+            pass
         if self.hc_api.oc_api.shared_cluster:
             pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "nodejs-imagestreams"
@@ -59,6 +62,9 @@ class TestHelmNodeJSApplication:
         )
 
     def test_by_helm_test(self):
+        # TODO VERSION 22 is not supported at all
+        if VERSION.startswith("22"):
+            pass
         self.hc_api.package_name = "nodejs-imagestreams"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/test/test_latest_imagestreams.py
+++ b/test/test_latest_imagestreams.py
@@ -22,6 +22,10 @@ class TestLatestImagestreams:
         print(TEST_DIR.parent.parent)
 
     def test_latest_imagestream(self):
+        # TODO VERSION 22 is not supported at all
+        if VERSION.startswith("22"):
+            pass
+
         self.latest_version = self.isc.get_latest_version()
         assert self.latest_version != ""
         self.isc.check_imagestreams(self.latest_version)

--- a/test/test_nodejs_ex_templates.py
+++ b/test/test_nodejs_ex_templates.py
@@ -42,6 +42,10 @@ class TestDeployNodeJSExTemplate:
         ]
     )
     def test_nodejs_ex_template_inside_cluster(self, template):
+        # TODO VERSION 22 is not supported at all
+        if VERSION.startswith("22"):
+            pass
+
         service_name = "nodejs-testing"
         template_url = self.oc_api.get_raw_url_for_json(
             container="nodejs-ex", dir="openshift/templates", filename=template, branch="master"


### PR DESCRIPTION
Do not tests version 22/22-minimal in OpenShift 4 yet










































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2373301417","data":[{"id":"167b8fc3-c895-4e10-994b-000c67ae222d","name":"RHEL9 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":728.432138,"created":"2024-09-25T07:27:46.836872","updated":"2024-09-25T07:27:46.836878","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/167b8fc3-c895-4e10-994b-000c67ae222d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/167b8fc3-c895-4e10-994b-000c67ae222d/pipeline.log\">pipeline</a>"]},{"id":"ee97393e-4291-44c9-981f-534797fe7144","name":"RHEL9 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":815.92422,"created":"2024-09-25T07:27:45.887548","updated":"2024-09-25T07:27:45.887554","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee97393e-4291-44c9-981f-534797fe7144\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee97393e-4291-44c9-981f-534797fe7144/pipeline.log\">pipeline</a>"]},{"id":"545ef039-aa8e-4778-9194-8ff492271892","name":"RHEL8 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":875.13235,"created":"2024-09-25T07:27:45.293456","updated":"2024-09-25T07:27:45.293463","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/545ef039-aa8e-4778-9194-8ff492271892\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/545ef039-aa8e-4778-9194-8ff492271892/pipeline.log\">pipeline</a>"]},{"id":"571a832c-64d0-4fc4-9faa-9d94503b6986","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":879.164286,"created":"2024-09-25T07:27:45.895897","updated":"2024-09-25T07:27:45.895904","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/571a832c-64d0-4fc4-9faa-9d94503b6986\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/571a832c-64d0-4fc4-9faa-9d94503b6986/pipeline.log\">pipeline</a>"]},{"id":"d6fb4ac1-c6e2-4ea8-880b-b724f14a93f6","name":"RHEL9 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":904.839609,"created":"2024-09-25T07:29:08.529293","updated":"2024-09-25T07:29:08.529300","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d6fb4ac1-c6e2-4ea8-880b-b724f14a93f6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d6fb4ac1-c6e2-4ea8-880b-b724f14a93f6/pipeline.log\">pipeline</a>"]},{"id":"3a03c3a5-90af-4f14-960d-7ad8f164324f","name":"RHEL8 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":926.475256,"created":"2024-09-25T07:28:59.087519","updated":"2024-09-25T07:28:59.087525","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a03c3a5-90af-4f14-960d-7ad8f164324f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a03c3a5-90af-4f14-960d-7ad8f164324f/pipeline.log\">pipeline</a>"]},{"id":"0bf89628-3aaf-4aba-8e73-243095036b3b","name":"RHEL9 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1158.162118,"created":"2024-09-25T07:27:44.057225","updated":"2024-09-25T07:27:44.057233","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0bf89628-3aaf-4aba-8e73-243095036b3b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0bf89628-3aaf-4aba-8e73-243095036b3b/pipeline.log\">pipeline</a>"]},{"id":"c2afcf80-a365-4f7f-84ca-bac0df45bd26","name":"RHEL8 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":870.000317,"created":"2024-09-25T07:33:36.974925","updated":"2024-09-25T07:33:36.974931","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2afcf80-a365-4f7f-84ca-bac0df45bd26\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2afcf80-a365-4f7f-84ca-bac0df45bd26/pipeline.log\">pipeline</a>"]},{"id":"9360dcea-2ad9-48a2-bc70-8d802ecddbf9","name":"RHEL9 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1319.66408,"created":"2024-09-25T07:27:43.658531","updated":"2024-09-25T07:27:43.658537","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9360dcea-2ad9-48a2-bc70-8d802ecddbf9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9360dcea-2ad9-48a2-bc70-8d802ecddbf9/pipeline.log\">pipeline</a>"]},{"id":"ee119b5d-c0d6-4309-aa06-ece5bd10581f","name":"RHEL8 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1305.229435,"created":"2024-09-25T07:27:42.624223","updated":"2024-09-25T07:27:42.624229","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee119b5d-c0d6-4309-aa06-ece5bd10581f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee119b5d-c0d6-4309-aa06-ece5bd10581f/pipeline.log\">pipeline</a>"]},{"id":"5af7017d-ae16-4d87-86a3-831957948e7b","name":"RHEL9 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1360.279011,"created":"2024-09-25T07:27:43.656994","updated":"2024-09-25T07:27:43.657001","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5af7017d-ae16-4d87-86a3-831957948e7b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5af7017d-ae16-4d87-86a3-831957948e7b/pipeline.log\">pipeline</a>"]},{"id":"75febfb2-e24f-4488-9cad-6e920786ea81","name":"RHEL8 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1365.884039,"created":"2024-09-25T07:27:44.490621","updated":"2024-09-25T07:27:44.490628","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/75febfb2-e24f-4488-9cad-6e920786ea81\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/75febfb2-e24f-4488-9cad-6e920786ea81/pipeline.log\">pipeline</a>"]},{"id":"d90db7d3-8ac7-4e27-8990-ad8500da8b1a","name":"RHEL8 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1377.431884,"created":"2024-09-25T07:27:46.931947","updated":"2024-09-25T07:27:46.931954","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d90db7d3-8ac7-4e27-8990-ad8500da8b1a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d90db7d3-8ac7-4e27-8990-ad8500da8b1a/pipeline.log\">pipeline</a>"]},{"id":"b2fe158f-1d3b-4164-a19c-6688617aae26","name":"RHEL8 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1415.307062,"created":"2024-09-25T07:27:43.487405","updated":"2024-09-25T07:27:43.487411","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2fe158f-1d3b-4164-a19c-6688617aae26\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2fe158f-1d3b-4164-a19c-6688617aae26/pipeline.log\">pipeline</a>"]},{"id":"4254b019-5cbf-4847-95b6-1501820f26d1","name":"RHEL9 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":818.934583,"created":"2024-09-25T07:39:59.305961","updated":"2024-09-25T07:39:59.305968","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4254b019-5cbf-4847-95b6-1501820f26d1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4254b019-5cbf-4847-95b6-1501820f26d1/pipeline.log\">pipeline</a>"]},{"id":"d09e3327-1920-4f2c-8366-9ef22bc49c6c","name":"RHEL9 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1830.159988,"created":"2024-09-25T07:27:46.980996","updated":"2024-09-25T07:27:46.981003","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d09e3327-1920-4f2c-8366-9ef22bc49c6c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d09e3327-1920-4f2c-8366-9ef22bc49c6c/pipeline.log\">pipeline</a>"]},{"id":"44762fcf-9e51-4a55-a6e1-d86485b032a1","name":"RHEL8 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1912.006731,"created":"2024-09-25T07:27:46.924245","updated":"2024-09-25T07:27:46.924252","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/44762fcf-9e51-4a55-a6e1-d86485b032a1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/44762fcf-9e51-4a55-a6e1-d86485b032a1/pipeline.log\">pipeline</a>"]},{"id":"8cded3c1-a840-43bc-9041-887c13eabcd0","name":"RHEL9 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1815.596098,"created":"2024-09-25T07:33:36.417680","updated":"2024-09-25T07:33:36.417687","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cded3c1-a840-43bc-9041-887c13eabcd0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cded3c1-a840-43bc-9041-887c13eabcd0/pipeline.log\">pipeline</a>"]},{"id":"5b2c4e63-92ab-474f-ab30-6bc0d5fc739b","name":"RHEL8 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1877.570035,"created":"2024-09-25T07:33:10.584936","updated":"2024-09-25T07:33:10.584943","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b2c4e63-92ab-474f-ab30-6bc0d5fc739b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5b2c4e63-92ab-474f-ab30-6bc0d5fc739b/pipeline.log\">pipeline</a>"]},{"id":"a1c76a3d-93cc-4e02-b149-7180d46e2f67","name":"Fedora - 18-minimal","status":"complete","outcome":"passed","runTime":1176.52062,"created":"2024-09-25T08:42:13.539929","updated":"2024-09-25T08:42:13.539938","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a1c76a3d-93cc-4e02-b149-7180d46e2f67\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a1c76a3d-93cc-4e02-b149-7180d46e2f67/pipeline.log\">pipeline</a>"]},{"id":"fd056700-b332-4d43-b151-27e7a32b5570","name":"Fedora - 18","status":"complete","outcome":"passed","runTime":2358.337032,"created":"2024-09-25T08:41:31.842821","updated":"2024-09-25T08:41:31.842828","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fd056700-b332-4d43-b151-27e7a32b5570\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fd056700-b332-4d43-b151-27e7a32b5570/pipeline.log\">pipeline</a>"]},{"id":"4d36abae-993b-4a22-852a-6daa10845f5f","name":"RHEL9 - 18-minimal","status":"complete","outcome":"passed","runTime":1622.579907,"created":"2024-09-25T08:53:56.111409","updated":"2024-09-25T08:53:56.111416","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4d36abae-993b-4a22-852a-6daa10845f5f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4d36abae-993b-4a22-852a-6daa10845f5f/pipeline.log\">pipeline</a>"]},{"id":"a0f367f6-869b-4ee1-b1e7-9725bb88f65a","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":1639.969972,"created":"2024-09-25T08:53:53.150632","updated":"2024-09-25T08:53:53.150639","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a0f367f6-869b-4ee1-b1e7-9725bb88f65a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a0f367f6-869b-4ee1-b1e7-9725bb88f65a/pipeline.log\">pipeline</a>"]},{"id":"2d2e5697-44b2-4104-b118-53373e6bcaf6","name":"RHEL9 - 18","status":"complete","outcome":"passed","runTime":2740.307241,"created":"2024-09-25T08:42:13.380185","updated":"2024-09-25T08:42:13.380194","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d2e5697-44b2-4104-b118-53373e6bcaf6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d2e5697-44b2-4104-b118-53373e6bcaf6/pipeline.log\">pipeline</a>"]},{"id":"3596a748-449c-4bf7-b8cd-21b81826b0cb","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":1200.074066,"created":"2024-09-25T09:08:44.610533","updated":"2024-09-25T09:08:44.610539","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3596a748-449c-4bf7-b8cd-21b81826b0cb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3596a748-449c-4bf7-b8cd-21b81826b0cb/pipeline.log\">pipeline</a>"]},{"id":"83c69c01-ae1e-4c4e-bf3c-57b5d5fc90f5","name":"RHEL8 - 18","status":"complete","outcome":"passed","runTime":2873.29003,"created":"2024-09-25T08:41:34.442158","updated":"2024-09-25T08:41:34.442167","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/83c69c01-ae1e-4c4e-bf3c-57b5d5fc90f5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/83c69c01-ae1e-4c4e-bf3c-57b5d5fc90f5/pipeline.log\">pipeline</a>"]},{"id":"edd438ee-7334-4f8e-8b02-d3a70592fd40","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":1228.684264,"created":"2024-09-25T09:12:32.991952","updated":"2024-09-25T09:12:32.991959","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/edd438ee-7334-4f8e-8b02-d3a70592fd40\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/edd438ee-7334-4f8e-8b02-d3a70592fd40/pipeline.log\">pipeline</a>"]},{"id":"9e7aa2f6-2a86-4296-afdf-c2e8c3777275","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":2360.692442,"created":"2024-09-25T08:56:55.212546","updated":"2024-09-25T08:56:55.212556","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9e7aa2f6-2a86-4296-afdf-c2e8c3777275\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9e7aa2f6-2a86-4296-afdf-c2e8c3777275/pipeline.log\">pipeline</a>"]},{"id":"e707ca3a-a32b-443d-a710-ab1381e320bc","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":2363.16003,"created":"2024-09-25T08:56:59.932207","updated":"2024-09-25T08:56:59.932213","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e707ca3a-a32b-443d-a710-ab1381e320bc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e707ca3a-a32b-443d-a710-ab1381e320bc/pipeline.log\">pipeline</a>"]},{"id":"3be89b50-6657-4e52-8024-8cead7036773","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":1110.235076,"created":"2024-09-25T09:24:00.840571","updated":"2024-09-25T09:24:00.840579","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3be89b50-6657-4e52-8024-8cead7036773\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3be89b50-6657-4e52-8024-8cead7036773/pipeline.log\">pipeline</a>"]},{"id":"f6aec6b6-d65f-4f8e-bf84-b270fc673ff3","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":1255.552251,"created":"2024-09-25T09:23:48.830030","updated":"2024-09-25T09:23:48.830037","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f6aec6b6-d65f-4f8e-bf84-b270fc673ff3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f6aec6b6-d65f-4f8e-bf84-b270fc673ff3/pipeline.log\">pipeline</a>"]},{"id":"09f55eaf-59ae-4b3a-a45a-57871fe86e22","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":2881.591089,"created":"2024-09-25T08:57:00.789008","updated":"2024-09-25T08:57:00.789015","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/09f55eaf-59ae-4b3a-a45a-57871fe86e22\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/09f55eaf-59ae-4b3a-a45a-57871fe86e22/pipeline.log\">pipeline</a>"]},{"id":"0f2a5bd9-f187-4d87-8b81-c2c960f186f8","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":1663.347293,"created":"2024-09-25T09:17:29.176730","updated":"2024-09-25T09:17:29.176737","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0f2a5bd9-f187-4d87-8b81-c2c960f186f8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0f2a5bd9-f187-4d87-8b81-c2c960f186f8/pipeline.log\">pipeline</a>"]},{"id":"28f59dc9-11db-4df0-a330-d7d4915d6f4a","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1482.336979,"created":"2024-09-25T09:21:30.568720","updated":"2024-09-25T09:21:30.568728","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/28f59dc9-11db-4df0-a330-d7d4915d6f4a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/28f59dc9-11db-4df0-a330-d7d4915d6f4a/pipeline.log\">pipeline</a>"]},{"id":"36057a21-eece-4dff-9cdb-c3d2efa80c6d","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":2863.14608,"created":"2024-09-25T09:02:15.652886","updated":"2024-09-25T09:02:15.652892","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/36057a21-eece-4dff-9cdb-c3d2efa80c6d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/36057a21-eece-4dff-9cdb-c3d2efa80c6d/pipeline.log\">pipeline</a>"]},{"id":"bd839c5c-d45f-4710-8aea-15ba14b4e097","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":1868.688716,"created":"2024-09-25T09:28:31.450430","updated":"2024-09-25T09:28:31.450436","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bd839c5c-d45f-4710-8aea-15ba14b4e097\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bd839c5c-d45f-4710-8aea-15ba14b4e097/pipeline.log\">pipeline</a>"]},{"id":"c1f57caf-9dbf-425d-88f5-af12f07963bc","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":2357.434243,"created":"2024-09-25T09:21:51.211430","updated":"2024-09-25T09:21:51.211439","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c1f57caf-9dbf-425d-88f5-af12f07963bc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c1f57caf-9dbf-425d-88f5-af12f07963bc/pipeline.log\">pipeline</a>"]},{"id":"48b7b461-538d-479a-bb45-1373c96c526b","name":"CentOS Stream 10 - 22","status":"complete","outcome":"failed","runTime":2413.321904,"created":"2024-09-25T09:21:38.395439","updated":"2024-09-25T09:21:38.395446","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/48b7b461-538d-479a-bb45-1373c96c526b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/48b7b461-538d-479a-bb45-1373c96c526b/pipeline.log\">pipeline</a>"]},{"id":"b9bd7a75-8ed2-4352-8e3d-b25bdb87a0cd","name":"RHEL9 - 22","runTime":2900.821169,"created":"2024-09-25T09:22:10.852371","updated":"2024-09-25T09:22:10.852378","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9bd7a75-8ed2-4352-8e3d-b25bdb87a0cd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9bd7a75-8ed2-4352-8e3d-b25bdb87a0cd/pipeline.log\">pipeline</a>"]}]} -->