### PR TITLE
Support build and push 22, and 22-minimal images to quay.io.

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,6 +30,22 @@ jobs:
             quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
 
+          - dockerfile: "22/Dockerfile.c10s"
+            docker_context: 22
+            registry_namespace: "sclorg"
+            tag: "c10s"
+            image_name: "nodejs-22-c10s"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+
+          - dockerfile: "22-minimal/Dockerfile.c10s"
+            docker_context: 22-minimal
+            registry_namespace: "sclorg"
+            tag: "c10s"
+            image_name: "nodejs-22-minimal-c10s"
+            quayio_username: "QUAY_IMAGE_SCLORG_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_SCLORG_BUILDER_TOKEN"
+
           - dockerfile: "18/Dockerfile.fedora"
             docker_context: 18
             registry_namespace: "fedora"
@@ -61,6 +77,23 @@ jobs:
             quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
             quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
             image_name: "nodejs-20-minimal"
+
+          - dockerfile: "22/Dockerfile.fedora"
+            docker_context: 22
+            registry_namespace: "fedora"
+            tag: "fedora"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            image_name: "nodejs-22"
+
+          - dockerfile: "22-minimal/Dockerfile.fedora"
+            docker_context: 22-minimal
+            registry_namespace: "fedora"
+            tag: "fedora"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            image_name: "nodejs-22-minimal"
+
     steps:
       - name: Build and push to quay.io registry
         uses: sclorg/build-and-push-action@v4


### PR DESCRIPTION
Support build and push 22, and 22-minimal images to quay.io.

The commit builds and push as Fedora, as CentOS Stream 10 images































































































































<!-- issue-commentator = {"comment-id":"2383270301"} -->

















































































































<!-- testing-farm = {"lock":"false","comment-id":"2383218174","data":[{"id":"28da38f5-6cf5-41a7-a2fe-4477a19c379f","name":"Fedora - 18-minimal","status":"complete","outcome":"passed","runTime":627.391503,"created":"2024-09-30T13:25:37.210726","updated":"2024-09-30T13:25:37.210736","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/28da38f5-6cf5-41a7-a2fe-4477a19c379f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/28da38f5-6cf5-41a7-a2fe-4477a19c379f/pipeline.log\">pipeline</a>"]},{"id":"9edfd320-39c3-48d5-be27-19d9fc0a3da9","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":576.308591,"created":"2024-09-30T13:26:15.533506","updated":"2024-09-30T13:26:15.533514","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9edfd320-39c3-48d5-be27-19d9fc0a3da9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9edfd320-39c3-48d5-be27-19d9fc0a3da9/pipeline.log\">pipeline</a>"]},{"id":"aaf1b821-e9a5-41bc-b943-3ee547f78c93","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":692.888563,"created":"2024-09-30T13:25:59.062710","updated":"2024-09-30T13:25:59.062719","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/aaf1b821-e9a5-41bc-b943-3ee547f78c93\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/aaf1b821-e9a5-41bc-b943-3ee547f78c93/pipeline.log\">pipeline</a>"]},{"id":"810b5514-2fe0-4820-a08d-ba9ce9a2cc83","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":802.162128,"created":"2024-09-30T13:25:59.806967","updated":"2024-09-30T13:25:59.806980","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/810b5514-2fe0-4820-a08d-ba9ce9a2cc83\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/810b5514-2fe0-4820-a08d-ba9ce9a2cc83/pipeline.log\">pipeline</a>"]},{"id":"890383c2-7e27-4384-9dce-c6325163537b","name":"Fedora - 18","status":"complete","outcome":"passed","runTime":867.080767,"created":"2024-09-30T13:25:36.303537","updated":"2024-09-30T13:25:36.303548","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/890383c2-7e27-4384-9dce-c6325163537b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/890383c2-7e27-4384-9dce-c6325163537b/pipeline.log\">pipeline</a>"]},{"id":"58096dd1-65cc-4f58-8f57-8a4f5db4e77c","name":"CentOS Stream 10 - 22","status":"complete","outcome":"failed","runTime":871.670255,"created":"2024-09-30T13:25:54.155266","updated":"2024-09-30T13:25:54.155275","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/58096dd1-65cc-4f58-8f57-8a4f5db4e77c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/58096dd1-65cc-4f58-8f57-8a4f5db4e77c/pipeline.log\">pipeline</a>"]},{"id":"b3cd1924-c129-418f-b856-a08defcc4e8a","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":961.081094,"created":"2024-09-30T13:25:37.765175","updated":"2024-09-30T13:25:37.765184","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b3cd1924-c129-418f-b856-a08defcc4e8a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b3cd1924-c129-418f-b856-a08defcc4e8a/pipeline.log\">pipeline</a>"]},{"id":"bf294528-f27f-42aa-b771-5c95cdcca699","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":968.233779,"created":"2024-09-30T13:25:37.792830","updated":"2024-09-30T13:25:37.792839","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bf294528-f27f-42aa-b771-5c95cdcca699\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bf294528-f27f-42aa-b771-5c95cdcca699/pipeline.log\">pipeline</a>"]},{"id":"e36a9714-c4f3-4675-aa2c-3f73a9538295","name":"RHEL9 - 18-minimal","status":"complete","outcome":"passed","runTime":1043.579681,"created":"2024-09-30T13:25:37.110314","updated":"2024-09-30T13:25:37.110323","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e36a9714-c4f3-4675-aa2c-3f73a9538295\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e36a9714-c4f3-4675-aa2c-3f73a9538295/pipeline.log\">pipeline</a>"]},{"id":"e76fbf5f-87f9-495d-8d25-d2a1f23efef0","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":1049.949968,"created":"2024-09-30T13:26:12.814819","updated":"2024-09-30T13:26:12.814826","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e76fbf5f-87f9-495d-8d25-d2a1f23efef0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e76fbf5f-87f9-495d-8d25-d2a1f23efef0/pipeline.log\">pipeline</a>"]},{"id":"e8db7728-e444-4b33-a8f4-402da85d1c20","name":"RHEL9 - 18","status":"complete","outcome":"passed","runTime":1107.532072,"created":"2024-09-30T13:25:37.130608","updated":"2024-09-30T13:25:37.130617","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8db7728-e444-4b33-a8f4-402da85d1c20\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8db7728-e444-4b33-a8f4-402da85d1c20/pipeline.log\">pipeline</a>"]},{"id":"19783157-6cd1-425c-805b-133a8517942b","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":1175.489861,"created":"2024-09-30T13:25:37.815474","updated":"2024-09-30T13:25:37.815482","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/19783157-6cd1-425c-805b-133a8517942b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/19783157-6cd1-425c-805b-133a8517942b/pipeline.log\">pipeline</a>"]},{"id":"a8aa7a23-f23b-4ef7-a76b-f12fc2d0d5f3","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":1225.238704,"created":"2024-09-30T13:25:49.543366","updated":"2024-09-30T13:25:49.543374","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a8aa7a23-f23b-4ef7-a76b-f12fc2d0d5f3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a8aa7a23-f23b-4ef7-a76b-f12fc2d0d5f3/pipeline.log\">pipeline</a>"]},{"id":"488758a6-ba13-4093-a1a6-0d3835ebb939","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1271.377241,"created":"2024-09-30T13:25:37.207412","updated":"2024-09-30T13:25:37.207420","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/488758a6-ba13-4093-a1a6-0d3835ebb939\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/488758a6-ba13-4093-a1a6-0d3835ebb939/pipeline.log\">pipeline</a>"]},{"id":"3d78e678-77e4-43e5-bcfa-583d85743a14","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1267.079001,"created":"2024-09-30T13:25:50.587451","updated":"2024-09-30T13:25:50.587458","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3d78e678-77e4-43e5-bcfa-583d85743a14\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3d78e678-77e4-43e5-bcfa-583d85743a14/pipeline.log\">pipeline</a>"]},{"id":"468d74d5-2bfc-41e3-b4d5-a818f640777c","name":"RHEL8 - 18","status":"complete","outcome":"failed","runTime":1410.265351,"created":"2024-09-30T13:25:36.361339","updated":"2024-09-30T13:25:36.361348","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/468d74d5-2bfc-41e3-b4d5-a818f640777c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/468d74d5-2bfc-41e3-b4d5-a818f640777c/pipeline.log\">pipeline</a>"]},{"id":"44caf2f7-138c-4778-8ab4-08d23501ccfa","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":1421.516102,"created":"2024-09-30T13:25:37.503907","updated":"2024-09-30T13:25:37.503916","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/44caf2f7-138c-4778-8ab4-08d23501ccfa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/44caf2f7-138c-4778-8ab4-08d23501ccfa/pipeline.log\">pipeline</a>"]},{"id":"769237f1-a911-4cfa-9235-727d1d29ff77","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1610.448789,"created":"2024-09-30T13:25:47.180911","updated":"2024-09-30T13:25:47.180919","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/769237f1-a911-4cfa-9235-727d1d29ff77\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/769237f1-a911-4cfa-9235-727d1d29ff77/pipeline.log\">pipeline</a>"]},{"id":"4667c666-bf04-4831-99a1-8326d0c3be5b","name":"RHEL8 - 20","status":"complete","outcome":"failed","runTime":1679.00244,"created":"2024-09-30T13:25:40.835238","updated":"2024-09-30T13:25:40.835250","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4667c666-bf04-4831-99a1-8326d0c3be5b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4667c666-bf04-4831-99a1-8326d0c3be5b/pipeline.log\">pipeline</a>"]},{"id":"dddab926-60e8-4394-9c8e-f24dfaa460ee","name":"RHEL9 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1138.261312,"created":"2024-09-30T13:36:41.721677","updated":"2024-09-30T13:36:41.721686","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dddab926-60e8-4394-9c8e-f24dfaa460ee\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dddab926-60e8-4394-9c8e-f24dfaa460ee/pipeline.log\">pipeline</a>"]},{"id":"2f3964c9-f8b6-4d29-b236-d110d6dc67c6","name":"RHEL9 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":1020.862265,"created":"2024-09-30T13:39:56.934351","updated":"2024-09-30T13:39:56.934362","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f3964c9-f8b6-4d29-b236-d110d6dc67c6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f3964c9-f8b6-4d29-b236-d110d6dc67c6/pipeline.log\">pipeline</a>"]},{"id":"53dacef6-357e-47a6-ae96-a04fe5bae2be","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":1948.82605,"created":"2024-09-30T13:25:46.630384","updated":"2024-09-30T13:25:46.630393","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/53dacef6-357e-47a6-ae96-a04fe5bae2be\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/53dacef6-357e-47a6-ae96-a04fe5bae2be/pipeline.log\">pipeline</a>"]},{"id":"eb97c061-2c34-46fa-977f-300fcf0c3274","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":1096.654556,"created":"2024-09-30T13:39:58.037510","updated":"2024-09-30T13:39:58.037521","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb97c061-2c34-46fa-977f-300fcf0c3274\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb97c061-2c34-46fa-977f-300fcf0c3274/pipeline.log\">pipeline</a>"]},{"id":"93dea48a-179c-4138-934c-6b10e54c4017","name":"RHEL9 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":982.557509,"created":"2024-09-30T13:42:34.648020","updated":"2024-09-30T13:42:34.648030","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/93dea48a-179c-4138-934c-6b10e54c4017\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/93dea48a-179c-4138-934c-6b10e54c4017/pipeline.log\">pipeline</a>"]},{"id":"59909d5a-7570-4d29-afbb-2d946f9af366","name":"RHEL9 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":994.646759,"created":"2024-09-30T13:45:34.286561","updated":"2024-09-30T13:45:34.286568","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/59909d5a-7570-4d29-afbb-2d946f9af366\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/59909d5a-7570-4d29-afbb-2d946f9af366/pipeline.log\">pipeline</a>"]},{"id":"84cec3ac-23e8-461a-83e1-6c3672ca99f5","name":"RHEL8 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1202.293849,"created":"2024-09-30T13:42:33.077434","updated":"2024-09-30T13:42:33.077535","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/84cec3ac-23e8-461a-83e1-6c3672ca99f5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/84cec3ac-23e8-461a-83e1-6c3672ca99f5/pipeline.log\">pipeline</a>"]},{"id":"2a26d93f-a0d3-4997-ae94-67d2af433428","name":"RHEL8 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1241.572764,"created":"2024-09-30T13:44:39.096573","updated":"2024-09-30T13:44:39.096581","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a26d93f-a0d3-4997-ae94-67d2af433428\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a26d93f-a0d3-4997-ae94-67d2af433428/pipeline.log\">pipeline</a>"]},{"id":"02596ce2-7198-4bdc-8a5f-39b9d71b5de4","name":"RHEL9 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1250.600411,"created":"2024-09-30T13:47:45.060570","updated":"2024-09-30T13:47:45.060577","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/02596ce2-7198-4bdc-8a5f-39b9d71b5de4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/02596ce2-7198-4bdc-8a5f-39b9d71b5de4/pipeline.log\">pipeline</a>"]},{"id":"0e8899eb-efde-4c1b-8537-2ea3032c294d","name":"RHEL9 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1153.340211,"created":"2024-09-30T13:49:57.504231","updated":"2024-09-30T13:49:57.504240","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e8899eb-efde-4c1b-8537-2ea3032c294d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e8899eb-efde-4c1b-8537-2ea3032c294d/pipeline.log\">pipeline</a>"]},{"id":"52c3c4c8-cb17-4b6f-9d29-a57fc550f57f","name":"RHEL8 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1398.821235,"created":"2024-09-30T13:47:57.299527","updated":"2024-09-30T13:47:57.299536","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/52c3c4c8-cb17-4b6f-9d29-a57fc550f57f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/52c3c4c8-cb17-4b6f-9d29-a57fc550f57f/pipeline.log\">pipeline</a>"]},{"id":"4ac86812-a267-42ec-b8b1-29d6e77c43e5","name":"RHEL8 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1507.282061,"created":"2024-09-30T13:47:41.947858","updated":"2024-09-30T13:47:41.947866","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ac86812-a267-42ec-b8b1-29d6e77c43e5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ac86812-a267-42ec-b8b1-29d6e77c43e5/pipeline.log\">pipeline</a>"]},{"id":"934b3c17-c102-48a9-baa7-bd891e94bdad","name":"RHEL9 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1215.770357,"created":"2024-09-30T13:54:13.874899","updated":"2024-09-30T13:54:13.874906","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/934b3c17-c102-48a9-baa7-bd891e94bdad\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/934b3c17-c102-48a9-baa7-bd891e94bdad/pipeline.log\">pipeline</a>"]},{"id":"2b01af30-17ab-442b-b1cb-425533ffc55f","name":"RHEL8 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1430.838528,"created":"2024-09-30T13:50:57.412911","updated":"2024-09-30T13:50:57.412922","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b01af30-17ab-442b-b1cb-425533ffc55f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b01af30-17ab-442b-b1cb-425533ffc55f/pipeline.log\">pipeline</a>"]},{"id":"600e3dbd-7eb7-4a9e-872c-c867988b1cc1","name":"RHEL9 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1979.098386,"created":"2024-09-30T13:41:59.601023","updated":"2024-09-30T13:41:59.601031","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/600e3dbd-7eb7-4a9e-872c-c867988b1cc1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/600e3dbd-7eb7-4a9e-872c-c867988b1cc1/pipeline.log\">pipeline</a>"]},{"id":"6f7f661b-ad74-4915-a4a3-c2553d759f3d","name":"RHEL9 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1895.114757,"created":"2024-09-30T13:44:03.656615","updated":"2024-09-30T13:44:03.656625","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f7f661b-ad74-4915-a4a3-c2553d759f3d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f7f661b-ad74-4915-a4a3-c2553d759f3d/pipeline.log\">pipeline</a>"]},{"id":"3a85a03a-eaea-4e09-be8d-1c13a7b3c00d","name":"RHEL8 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":2170.254304,"created":"2024-09-30T13:40:32.191428","updated":"2024-09-30T13:40:32.191434","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a85a03a-eaea-4e09-be8d-1c13a7b3c00d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a85a03a-eaea-4e09-be8d-1c13a7b3c00d/pipeline.log\">pipeline</a>"]},{"id":"e69a4e3f-7399-4625-8bfe-f96438773afd","name":"RHEL8 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1333.56028,"created":"2024-09-30T13:54:29.175418","updated":"2024-09-30T13:54:29.175425","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e69a4e3f-7399-4625-8bfe-f96438773afd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e69a4e3f-7399-4625-8bfe-f96438773afd/pipeline.log\">pipeline</a>"]},{"id":"78b6ce4f-9d49-4cc1-a368-a2df85941a66","name":"RHEL9 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1296.532809,"created":"2024-09-30T13:56:08.135683","updated":"2024-09-30T13:56:08.135692","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/78b6ce4f-9d49-4cc1-a368-a2df85941a66\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/78b6ce4f-9d49-4cc1-a368-a2df85941a66/pipeline.log\">pipeline</a>"]},{"id":"23946872-b549-4bde-a36f-c360c3e81702","name":"RHEL8 - PyTest - OpenShift 4 - 20","runTime":2086.149168,"created":"2024-09-30T13:43:38.299076","updated":"2024-09-30T13:43:38.299085","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/23946872-b549-4bde-a36f-c360c3e81702\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/23946872-b549-4bde-a36f-c360c3e81702/pipeline.log\">pipeline</a>"]}]} -->