### PR TITLE
Use ct_check_testcase_result instead of check_result

### DIFF
--- a/test/run-minimal
+++ b/test/run-minimal
@@ -121,12 +121,12 @@ TEST_SET=${TESTS:-$TEST_LIST_HW} ct_run_tests_from_testset "hw"
 
 echo "Testing the development image build: s2i build -e \"NODE_ENV=development\")"
 run_s2i_build "-e NODE_ENV=development"
-check_result $?
+ct_check_testcase_result $?
 
 TEST_SET=${TESTS:-$TEST_LIST_NODE_ENV} ct_run_tests_from_testset "node_env_development"
 
 echo "Testing the development image build: s2i build -e \"DEV_MODE=true\")"
 run_s2i_build "-e DEV_MODE=true"
-check_result $?
+ct_check_testcase_result $?
 
 TEST_SET=${TESTS:-$TEST_LIST_DEV_MODE} ct_run_tests_from_testset "dev_mode"


### PR DESCRIPTION
The `ct_check_testcase_result` seems to be the right function to use instead of `check_result`

Fix: #456

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
