### PR TITLE
Fix assemble cache clean order in 16-minimal, 18-minimal

### DIFF
--- a/16-minimal/s2i/bin/assemble
+++ b/16-minimal/s2i/bin/assemble
@@ -96,6 +96,12 @@ else
 	npm prune
 
 	# Clear the npm's cache and tmp directories only if they are not a docker volumes
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
 	NPM_CACHE=$(npm config get cache)
 	if ! mountpoint $NPM_CACHE; then
 		echo "---> Cleaning the npm cache $NPM_CACHE"
@@ -103,11 +109,6 @@ else
 		# instead of $NPM_CACHE* use $NPM_CACHE/*.
 		# We do not want to delete .npmrc file.
 		rm -rf "${NPM_CACHE:?}/"
-	fi
-	NPM_TMP=$(npm config get tmp)
-	if ! mountpoint $NPM_TMP; then
-		echo "---> Cleaning the $NPM_TMP/npm-*"
-		rm -rf $NPM_TMP/npm-*
 	fi
 
 fi

--- a/18-minimal/s2i/bin/assemble
+++ b/18-minimal/s2i/bin/assemble
@@ -96,6 +96,12 @@ else
 	npm prune
 
 	# Clear the npm's cache and tmp directories only if they are not a docker volumes
+	NPM_TMP=$(npm config get tmp)
+	if ! mountpoint $NPM_TMP; then
+		echo "---> Cleaning the $NPM_TMP/npm-*"
+		rm -rf $NPM_TMP/npm-*
+	fi
+
 	NPM_CACHE=$(npm config get cache)
 	if ! mountpoint $NPM_CACHE; then
 		echo "---> Cleaning the npm cache $NPM_CACHE"
@@ -103,11 +109,6 @@ else
 		# instead of $NPM_CACHE* use $NPM_CACHE/*.
 		# We do not want to delete .npmrc file.
 		rm -rf "${NPM_CACHE:?}/"
-	fi
-	NPM_TMP=$(npm config get tmp)
-	if ! mountpoint $NPM_TMP; then
-		echo "---> Cleaning the $NPM_TMP/npm-*"
-		rm -rf $NPM_TMP/npm-*
 	fi
 
 fi


### PR DESCRIPTION
Removal of the cache has to be the last things done in the assemble script. Calling `npm` after deleting the cache folder will cause npm to recreate it - which will fail during the image test.

Other images apparently have it correctly, for some reason this error is present only in 16-minimal and 18-minimal.

<!-- issue-commentator = {"comment-id":"2422569368"} -->















































































































































<!-- testing-farm = {"lock":"false","comment-id":"2437315516","data":[{"id":"8e5bd698-0332-4528-96e8-16947b5d78cb","name":"Fedora - 18-minimal","status":"complete","outcome":"passed","runTime":612.31619,"created":"2024-10-25T09:15:23.031737","updated":"2024-10-25T09:15:23.031746","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8e5bd698-0332-4528-96e8-16947b5d78cb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8e5bd698-0332-4528-96e8-16947b5d78cb/pipeline.log\">pipeline</a>"]},{"id":"b9f0c3ad-7e52-4148-9905-4623dbf9c085","name":"Fedora - 18","status":"complete","outcome":"passed","runTime":849.659669,"created":"2024-10-25T09:15:25.820572","updated":"2024-10-25T09:15:25.820578","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b9f0c3ad-7e52-4148-9905-4623dbf9c085\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b9f0c3ad-7e52-4148-9905-4623dbf9c085/pipeline.log\">pipeline</a>"]},{"id":"f452a437-5875-4892-b003-b72268ca23ab","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":925.915616,"created":"2024-10-25T09:17:27.953821","updated":"2024-10-25T09:17:27.953827","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f452a437-5875-4892-b003-b72268ca23ab\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f452a437-5875-4892-b003-b72268ca23ab/pipeline.log\">pipeline</a>"]},{"id":"1fab6f06-0b6f-4c9d-99b7-6cc6c7ea4a00","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":945.253713,"created":"2024-10-25T09:18:34.358662","updated":"2024-10-25T09:18:34.358668","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1fab6f06-0b6f-4c9d-99b7-6cc6c7ea4a00\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1fab6f06-0b6f-4c9d-99b7-6cc6c7ea4a00/pipeline.log\">pipeline</a>"]},{"id":"8cbf3dda-7723-4212-90c0-6dc5e1256e8d","name":"RHEL9 - 18-minimal","status":"complete","outcome":"passed","runTime":1171.279675,"created":"2024-10-25T09:15:33.978475","updated":"2024-10-25T09:15:33.978483","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cbf3dda-7723-4212-90c0-6dc5e1256e8d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cbf3dda-7723-4212-90c0-6dc5e1256e8d/pipeline.log\">pipeline</a>"]},{"id":"b4ed782f-4a1d-48e9-9731-37bdf83559e4","name":"CentOS Stream 10 - 22","status":"complete","outcome":"failed","runTime":648.20408,"created":"2024-11-04T08:47:11.761651","updated":"2024-11-04T08:47:11.761657","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b4ed782f-4a1d-48e9-9731-37bdf83559e4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b4ed782f-4a1d-48e9-9731-37bdf83559e4/pipeline.log\">pipeline</a>"]},{"id":"61ba0c59-dec1-45b8-8d3a-fd26fc3a2a87","name":"RHEL9 - 18","status":"complete","outcome":"passed","runTime":1262.902642,"created":"2024-10-25T09:15:27.015035","updated":"2024-10-25T09:15:27.015046","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/61ba0c59-dec1-45b8-8d3a-fd26fc3a2a87\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/61ba0c59-dec1-45b8-8d3a-fd26fc3a2a87/pipeline.log\">pipeline</a>"]},{"id":"6acbdcd6-ebb5-49b8-bede-0ff3b3c3fea6","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":1113.286605,"created":"2024-11-04T08:47:10.212428","updated":"2024-11-04T08:47:10.212434","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6acbdcd6-ebb5-49b8-bede-0ff3b3c3fea6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6acbdcd6-ebb5-49b8-bede-0ff3b3c3fea6/pipeline.log\">pipeline</a>"]},{"id":"1443a5f3-4a95-4e4c-b5a9-e5f10d60d272","name":"RHEL8 - 18","status":"complete","outcome":"passed","runTime":1456.959039,"created":"2024-10-25T09:15:26.045232","updated":"2024-10-25T09:15:26.045239","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1443a5f3-4a95-4e4c-b5a9-e5f10d60d272\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1443a5f3-4a95-4e4c-b5a9-e5f10d60d272/pipeline.log\">pipeline</a>"]},{"id":"1201799a-431b-4cc6-acbc-19fb14c755ce","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":1149.757021,"created":"2024-10-25T09:21:42.715848","updated":"2024-10-25T09:21:42.715855","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1201799a-431b-4cc6-acbc-19fb14c755ce\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1201799a-431b-4cc6-acbc-19fb14c755ce/pipeline.log\">pipeline</a>"]},{"id":"355dbea3-520d-4667-90f4-7b7885a0c8c7","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1236.457556,"created":"2024-10-25T09:21:04.981150","updated":"2024-10-25T09:21:04.981157","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/355dbea3-520d-4667-90f4-7b7885a0c8c7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/355dbea3-520d-4667-90f4-7b7885a0c8c7/pipeline.log\">pipeline</a>"]},{"id":"f6c23e00-3da2-4d28-84e7-6beb25a44e9e","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":506.161496,"created":"2024-10-25T09:33:12.749160","updated":"2024-10-25T09:33:12.749168","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f6c23e00-3da2-4d28-84e7-6beb25a44e9e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f6c23e00-3da2-4d28-84e7-6beb25a44e9e/pipeline.log\">pipeline</a>"]},{"id":"eb92c780-b9bf-4a5d-b834-b8567c5ae6e6","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1620.280879,"created":"2024-10-25T09:15:36.902680","updated":"2024-10-25T09:15:36.902687","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb92c780-b9bf-4a5d-b834-b8567c5ae6e6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eb92c780-b9bf-4a5d-b834-b8567c5ae6e6/pipeline.log\">pipeline</a>"]},{"id":"442282dd-8c8d-4bcb-b80a-e1aaaa2447df","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":1212.092371,"created":"2024-10-25T09:23:37.134577","updated":"2024-10-25T09:23:37.134585","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/442282dd-8c8d-4bcb-b80a-e1aaaa2447df\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/442282dd-8c8d-4bcb-b80a-e1aaaa2447df/pipeline.log\">pipeline</a>"]},{"id":"76deb2b1-4e7a-4a16-b530-6ea7223bf727","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":795.765912,"created":"2024-10-25T09:30:49.926156","updated":"2024-10-25T09:30:49.926164","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/76deb2b1-4e7a-4a16-b530-6ea7223bf727\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/76deb2b1-4e7a-4a16-b530-6ea7223bf727/pipeline.log\">pipeline</a>"]},{"id":"8676ab40-c363-4c19-b970-c5a03407e007","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":643.953321,"created":"2024-10-25T09:34:55.117692","updated":"2024-10-25T09:34:55.117700","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8676ab40-c363-4c19-b970-c5a03407e007\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8676ab40-c363-4c19-b970-c5a03407e007/pipeline.log\">pipeline</a>"]},{"id":"cc310e9c-4c7b-43da-8fb4-cc916ed91ed7","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":1050.15805,"created":"2024-10-25T09:35:24.198033","updated":"2024-10-25T09:35:24.198040","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc310e9c-4c7b-43da-8fb4-cc916ed91ed7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc310e9c-4c7b-43da-8fb4-cc916ed91ed7/pipeline.log\">pipeline</a>"]},{"id":"debedbb8-ef49-4c22-aa4d-7c0be37be83b","name":"RHEL8 - 20-minimal","runTime":1588.4804,"created":"2024-11-04T08:47:13.971934","updated":"2024-11-04T08:47:13.971941","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/debedbb8-ef49-4c22-aa4d-7c0be37be83b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/debedbb8-ef49-4c22-aa4d-7c0be37be83b/pipeline.log\">pipeline</a>"]},{"id":"4439a4c5-6d98-44f8-8532-176521a76118","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1286.49433,"created":"2024-11-04T08:47:15.614702","updated":"2024-11-04T08:47:15.614709","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4439a4c5-6d98-44f8-8532-176521a76118\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4439a4c5-6d98-44f8-8532-176521a76118/pipeline.log\">pipeline</a>"]},{"id":"3f695a51-bf31-4f25-93af-858734521792","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1655.156681,"created":"2024-10-25T09:26:12.201077","updated":"2024-10-25T09:26:12.201084","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f695a51-bf31-4f25-93af-858734521792\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f695a51-bf31-4f25-93af-858734521792/pipeline.log\">pipeline</a>"]}]} -->