### PR TITLE
Add support for NodeJS-22 imagestreams.

### DIFF
--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -9,13 +9,13 @@
     https://github.com/sclorg/s2i-nodejs-container/blob/master/APP_VERSION/README.md.
   imagestream_files:
   - filename: nodejs-centos.json
-    latest: "20-ubi9"
+    latest: "22-ubi9"
     distros:
       - name: UBI 8
         app_versions: ["18", "18-minimal", "20", "20-minimal"]
 
       - name: UBI 9
-        app_versions: ["18", "18-minimal", "20", "20-minimal"]
+        app_versions: ["18", "18-minimal", "20", "20-minimal", "22", "22-minimal"]
     custom_tags:
       - name: "18-ubi8-minimal"
         distro: UBI 8
@@ -29,15 +29,18 @@
       - name: "20-ubi9-minimal"
         distro: UBI 9
         app_version: "20-minimal"
+      - name: "22-ubi9-minimal"
+        distro: UBI 9
+        app_version: "22-minimal"
 
   - filename: nodejs-rhel.json
-    latest: "20-ubi9"
+    latest: "22-ubi9"
     distros:
       - name: UBI 8
         app_versions: ["18", "18-minimal", "20", "20-minimal"]
 
       - name: UBI 9
-        app_versions: ["18", "18-minimal", "20", "20-minimal"]
+        app_versions: ["18", "18-minimal", "20", "20-minimal", "22", "22-minimal"]
     # these are non standard tags, maintained for backwards compatibility
     custom_tags:
       - name: "18-ubi8-minimal"
@@ -52,15 +55,18 @@
       - name: "20-ubi9-minimal"
         distro: UBI 9
         app_version: "20-minimal"
+      - name: "22-ubi9-minimal"
+        distro: UBI 9
+        app_version: "22-minimal"
 
   - filename: nodejs-rhel-aarch64.json
-    latest: "20-ubi9"
+    latest: "22-ubi9"
     distros:
       - name: UBI 8
         app_versions: ["18", "18-minimal", "20", "20-minimal"]
 
       - name: UBI 9
-        app_versions: ["18", "18-minimal", "20", "20-minimal"]
+        app_versions: ["18", "18-minimal", "20", "20-minimal", "22", "22-minimal"]
     custom_tags:
       - name: "18-ubi8-minimal"
         distro: UBI 8
@@ -74,4 +80,7 @@
       - name: "20-ubi9-minimal"
         distro: UBI 9
         app_version: "20-minimal"
+      - name: "22-ubi9-minimal"
+        distro: UBI 9
+        app_version: "22-minimal"
 ...

--- a/imagestreams/nodejs-centos.json
+++ b/imagestreams/nodejs-centos.json
@@ -162,6 +162,44 @@
         }
       },
       {
+        "name": "22-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi9/nodejs-22:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-minimal-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi9/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "18-ubi8-minimal",
         "annotations": {
           "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
@@ -238,19 +276,38 @@
         }
       },
       {
-        "name": "latest",
+        "name": "22-ubi9-minimal",
         "annotations": {
-          "openshift.io/display-name": "Node.js 20 (Latest)",
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+          "description": "Build and run Node.js 22-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
-          "version": "20",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi9/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
           "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "20-ubi9"
+          "name": "22-ubi9"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nodejs-rhel-aarch64.json
+++ b/imagestreams/nodejs-rhel-aarch64.json
@@ -162,6 +162,44 @@
         }
       },
       {
+        "name": "22-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/nodejs-22:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-minimal-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "18-ubi8-minimal",
         "annotations": {
           "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
@@ -238,19 +276,38 @@
         }
       },
       {
-        "name": "latest",
+        "name": "22-ubi9-minimal",
         "annotations": {
-          "openshift.io/display-name": "Node.js 20 (Latest)",
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+          "description": "Build and run Node.js 22-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
-          "version": "20",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
           "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "20-ubi9"
+          "name": "22-ubi9"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nodejs-rhel.json
+++ b/imagestreams/nodejs-rhel.json
@@ -162,6 +162,44 @@
         }
       },
       {
+        "name": "22-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/nodejs-22:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-minimal-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "18-ubi8-minimal",
         "annotations": {
           "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
@@ -238,19 +276,38 @@
         }
       },
       {
-        "name": "latest",
+        "name": "22-ubi9-minimal",
         "annotations": {
-          "openshift.io/display-name": "Node.js 20 (Latest)",
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 9)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 20 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/20/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+          "description": "Build and run Node.js 22-minimal applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
           "iconClass": "icon-nodejs",
           "tags": "builder,nodejs",
-          "version": "20",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
           "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "20-ubi9"
+          "name": "22-ubi9"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -46,11 +46,6 @@ test -n "${VERSION-}" || false 'make sure $VERSION is defined'
 export CT_OCP4_TEST=true
 export CT_SKIP_UPLOAD_IMAGE=true
 
-# TODO VERSION 22 is not supported at all
-if [ "${VERSION}" == "22" ] || [ "${VERSION}" == "22-minimal" ]; then
-  exit 0
-fi
-
 TEST_SUMMARY=''
 TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "openshift-remote-cluster"
 

--- a/test/test_latest_imagestreams.py
+++ b/test/test_latest_imagestreams.py
@@ -22,10 +22,6 @@ class TestLatestImagestreams:
         print(TEST_DIR.parent.parent)
 
     def test_latest_imagestream(self):
-        # TODO VERSION 22 is not supported at all
-        if VERSION.startswith("22"):
-            pass
-
         self.latest_version = self.isc.get_latest_version()
         assert self.latest_version != ""
         self.isc.check_imagestreams(self.latest_version)

--- a/test/test_nodejs_ex_templates.py
+++ b/test/test_nodejs_ex_templates.py
@@ -42,10 +42,6 @@ class TestDeployNodeJSExTemplate:
         ]
     )
     def test_nodejs_ex_template_inside_cluster(self, template):
-        # TODO VERSION 22 is not supported at all
-        if VERSION.startswith("22"):
-            pass
-
         service_name = "nodejs-testing"
         template_url = self.oc_api.get_raw_url_for_json(
             container="nodejs-ex", dir="openshift/templates", filename=template, branch="master"

--- a/test/test_shared_helm_nodejs_application.py
+++ b/test/test_shared_helm_nodejs_application.py
@@ -27,9 +27,9 @@ TAG = TAGS.get(OS, None)
 class TestHelmNodeJSApplication:
 
     def setup_method(self):
-        package_name = "nodejs-application"
+        package_name = "redhat-nodejs-application"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"
@@ -39,9 +39,6 @@ class TestHelmNodeJSApplication:
         self.hc_api.delete_project()
 
     def test_curl_connection(self):
-        # TODO VERSION 22 is not supported at all
-        if VERSION.startswith("22"):
-            pass
         if self.hc_api.oc_api.shared_cluster:
             pytest.skip("Do NOT test on shared cluster")
         self.hc_api.package_name = "nodejs-imagestreams"
@@ -62,9 +59,6 @@ class TestHelmNodeJSApplication:
         )
 
     def test_by_helm_test(self):
-        # TODO VERSION 22 is not supported at all
-        if VERSION.startswith("22"):
-            pass
         self.hc_api.package_name = "nodejs-imagestreams"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation()

--- a/test/test_shared_helm_nodejs_imagestreams.py
+++ b/test/test_shared_helm_nodejs_imagestreams.py
@@ -17,9 +17,9 @@ test_dir = Path(os.path.abspath(os.path.dirname(__file__)))
 class TestHelmRHELNodeJSImageStreams:
 
     def setup_method(self):
-        package_name = "nodejs-imagestreams"
+        package_name = "redhat-nodejs-imagestreams"
         path = test_dir
-        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir, remote=True)
+        self.hc_api = HelmChartsAPI(path=path, package_name=package_name, tarball_dir=test_dir)
         self.hc_api.clone_helm_chart_repo(
             repo_url="https://github.com/sclorg/helm-charts", repo_name="helm-charts",
             subdir="charts/redhat"
@@ -31,6 +31,8 @@ class TestHelmRHELNodeJSImageStreams:
     @pytest.mark.parametrize(
         "version,registry",
         [
+            ("22-ubi9", "registry.redhat.io/ubi9/nodejs-22:latest"),
+            ("22-ubi9-minimal", "registry.redhat.io/ubi9/nodejs-22-minimal:latest"),
             ("20-ubi9", "registry.redhat.io/ubi9/nodejs-20:latest"),
             ("20-ubi9-minimal", "registry.redhat.io/ubi9/nodejs-20-minimal:latest"),
             ("20-ubi8", "registry.redhat.io/ubi8/nodejs-20:latest"),


### PR DESCRIPTION
Add support for NodeJS-22 imagestreams.
RHEL-9.5.0 reached GA and imagestream is present in registry.

The commit allows to test it.

The other relevant pull requests are:
Helm charts PR: https://github.com/sclorg/helm-charts/pull/115
Ansible-tests PR: https://github.com/sclorg/ansible-tests/pull/80
NodeJS-ex PR: https://github.com/sclorg/nodejs-ex/pull/285

<!-- issue-commentator = {"comment-id":"2478712855"} -->































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2485082881","data":[{"id":"0d5c0ff3-e77e-4a7c-bf31-7f84e3656bbd","name":"RHEL8 - PyTest - OpenShift 4 - 20","runTime":2270.133766,"created":"2024-11-26T09:08:50.831620","updated":"2024-11-26T09:08:50.831627","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d5c0ff3-e77e-4a7c-bf31-7f84e3656bbd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d5c0ff3-e77e-4a7c-bf31-7f84e3656bbd/pipeline.log\">pipeline</a>"]},{"id":"4b49e095-ec78-46c9-9774-84291a719364","name":"RHEL9 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1835.825117,"created":"2024-11-21T16:10:35.850614","updated":"2024-11-21T16:10:35.850625","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b49e095-ec78-46c9-9774-84291a719364\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b49e095-ec78-46c9-9774-84291a719364/pipeline.log\">pipeline</a>"]},{"id":"31a60d00-6373-454c-a852-9d5f6b90d5ab","name":"RHEL9 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":2360.176609,"created":"2024-11-21T15:50:29.178426","updated":"2024-11-21T15:50:29.178433","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/31a60d00-6373-454c-a852-9d5f6b90d5ab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/31a60d00-6373-454c-a852-9d5f6b90d5ab/pipeline.log\">pipeline</a>"]},{"id":"b7418038-1e57-40a3-8f19-9f30d6b85196","name":"RHEL9 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1584.294433,"created":"2024-11-21T16:15:00.688336","updated":"2024-11-21T16:15:00.688344","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b7418038-1e57-40a3-8f19-9f30d6b85196\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b7418038-1e57-40a3-8f19-9f30d6b85196/pipeline.log\">pipeline</a>"]},{"id":"5a9bd825-66c3-4bff-978b-1c8c5742ec25","name":"RHEL9 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"error","runTime":2045.905312,"created":"2024-11-26T09:08:50.758385","updated":"2024-11-26T09:08:50.758391","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5a9bd825-66c3-4bff-978b-1c8c5742ec25\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5a9bd825-66c3-4bff-978b-1c8c5742ec25/pipeline.log\">pipeline</a>"]},{"id":"c7c86842-d057-4705-9f1f-86d8dbb06ea5","name":"RHEL8 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":1048.326475,"created":"2024-11-21T16:18:00.168955","updated":"2024-11-21T16:18:00.168964","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c7c86842-d057-4705-9f1f-86d8dbb06ea5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c7c86842-d057-4705-9f1f-86d8dbb06ea5/pipeline.log\">pipeline</a>"]},{"id":"1493dd47-babc-446f-a033-d27c33219ed1","name":"RHEL9 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":678.72978,"created":"2024-11-21T16:20:06.448657","updated":"2024-11-21T16:20:06.448666","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1493dd47-babc-446f-a033-d27c33219ed1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1493dd47-babc-446f-a033-d27c33219ed1/pipeline.log\">pipeline</a>"]},{"id":"93ab34e2-c8b2-4d8d-badd-7b2f363ac4a9","name":"RHEL8 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1655.263772,"created":"2024-11-21T16:14:29.734704","updated":"2024-11-21T16:14:29.734718","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/93ab34e2-c8b2-4d8d-badd-7b2f363ac4a9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/93ab34e2-c8b2-4d8d-badd-7b2f363ac4a9/pipeline.log\">pipeline</a>"]},{"id":"015191ba-d8b3-4ba3-83f9-6341d840dbd2","name":"RHEL9 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":876.791947,"created":"2024-11-26T09:08:54.532068","updated":"2024-11-26T09:08:54.532077","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/015191ba-d8b3-4ba3-83f9-6341d840dbd2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/015191ba-d8b3-4ba3-83f9-6341d840dbd2/pipeline.log\">pipeline</a>"]},{"id":"07139a63-f9f8-469f-bb40-7ed74dbc6034","name":"RHEL9 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1585.828731,"created":"2024-11-21T16:14:02.185364","updated":"2024-11-21T16:14:02.185370","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/07139a63-f9f8-469f-bb40-7ed74dbc6034\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/07139a63-f9f8-469f-bb40-7ed74dbc6034/pipeline.log\">pipeline</a>"]},{"id":"0021e984-0cd3-405b-a3a0-46b029a8f36b","name":"RHEL9 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"error","runTime":2018.277269,"created":"2024-11-26T09:08:51.425754","updated":"2024-11-26T09:08:51.425762","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0021e984-0cd3-405b-a3a0-46b029a8f36b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0021e984-0cd3-405b-a3a0-46b029a8f36b/pipeline.log\">pipeline</a>"]},{"id":"73a4c0c4-bce6-4c61-8cd5-28af2b142144","name":"RHEL8 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1784.35104,"created":"2024-11-21T16:14:01.102265","updated":"2024-11-21T16:14:01.102275","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/73a4c0c4-bce6-4c61-8cd5-28af2b142144\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/73a4c0c4-bce6-4c61-8cd5-28af2b142144/pipeline.log\">pipeline</a>"]},{"id":"6cfe55ad-f8c1-4c1b-8a0f-4f74ab376ddd","name":"RHEL9 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":3482.996025,"created":"2024-11-21T16:21:32.067314","updated":"2024-11-21T16:21:32.067324","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6cfe55ad-f8c1-4c1b-8a0f-4f74ab376ddd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6cfe55ad-f8c1-4c1b-8a0f-4f74ab376ddd/pipeline.log\">pipeline</a>"]},{"id":"ffe6a83c-a1f6-47b7-8bec-525cbfa097be","name":"RHEL8 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":3244.146669,"created":"2024-11-21T16:28:29.249272","updated":"2024-11-21T16:28:29.249279","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ffe6a83c-a1f6-47b7-8bec-525cbfa097be\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ffe6a83c-a1f6-47b7-8bec-525cbfa097be/pipeline.log\">pipeline</a>"]},{"id":"170567ed-6523-483c-80d5-ca67d334a924","name":"RHEL8 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":2614.59172,"created":"2024-11-21T15:51:39.949931","updated":"2024-11-21T15:51:39.949939","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/170567ed-6523-483c-80d5-ca67d334a924\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/170567ed-6523-483c-80d5-ca67d334a924/pipeline.log\">pipeline</a>"]},{"id":"653e1d09-1078-45ab-980a-5827cc186706","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":3537.679295,"created":"2024-11-21T16:21:30.475571","updated":"2024-11-21T16:21:30.475579","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/653e1d09-1078-45ab-980a-5827cc186706\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/653e1d09-1078-45ab-980a-5827cc186706/pipeline.log\">pipeline</a>"]},{"id":"5528ce99-bfe3-43b3-99e2-dc1ae8c82047","name":"RHEL8 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":3846.773166,"created":"2024-11-21T16:35:50.038072","updated":"2024-11-21T16:35:50.038084","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5528ce99-bfe3-43b3-99e2-dc1ae8c82047\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5528ce99-bfe3-43b3-99e2-dc1ae8c82047/pipeline.log\">pipeline</a>"]},{"id":"052eef77-f343-4097-8b14-ba726de1083e","name":"RHEL8 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"error","runTime":2072.588998,"created":"2024-11-26T09:08:50.766088","updated":"2024-11-26T09:08:50.766097","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/052eef77-f343-4097-8b14-ba726de1083e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/052eef77-f343-4097-8b14-ba726de1083e/pipeline.log\">pipeline</a>"]},{"id":"b28005b5-66d1-4951-abe6-7c91945cd1ab","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":510.959456,"created":"2024-11-21T16:03:01.706258","updated":"2024-11-21T16:03:01.706270","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b28005b5-66d1-4951-abe6-7c91945cd1ab\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b28005b5-66d1-4951-abe6-7c91945cd1ab/pipeline.log\">pipeline</a>"]},{"id":"6a10d78e-8200-4480-83f0-4952c43e2339","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":975.418864,"created":"2024-11-21T15:51:31.228826","updated":"2024-11-21T15:51:31.228832","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6a10d78e-8200-4480-83f0-4952c43e2339\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6a10d78e-8200-4480-83f0-4952c43e2339/pipeline.log\">pipeline</a>"]},{"id":"b89425eb-8822-4a24-b0fa-a0a7371afd9d","name":"Fedora - 22-minimal","status":"complete","outcome":"error","runTime":723.990751,"created":"2024-11-21T16:08:39.987672","updated":"2024-11-21T16:08:39.987680","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b89425eb-8822-4a24-b0fa-a0a7371afd9d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b89425eb-8822-4a24-b0fa-a0a7371afd9d/pipeline.log\">pipeline</a>"]},{"id":"bfd288d8-a1d3-477f-9c92-2c697b98899e","name":"Fedora - 18-minimal","status":"complete","outcome":"error","runTime":1580.959357,"created":"2024-11-21T15:32:43.136346","updated":"2024-11-21T15:32:43.136356","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bfd288d8-a1d3-477f-9c92-2c697b98899e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bfd288d8-a1d3-477f-9c92-2c697b98899e/pipeline.log\">pipeline</a>"]},{"id":"5c76b918-8d5f-4afb-8861-9e60fca784e1","name":"Fedora - 18","status":"complete","outcome":"error","runTime":1949.291122,"created":"2024-11-21T15:27:28.484792","updated":"2024-11-21T15:27:28.484800","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5c76b918-8d5f-4afb-8861-9e60fca784e1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5c76b918-8d5f-4afb-8861-9e60fca784e1/pipeline.log\">pipeline</a>"]},{"id":"e91557d9-cb8f-4a6f-b38f-8b4f6e654b19","name":"Fedora - 22","status":"complete","outcome":"error","runTime":1032.062271,"created":"2024-11-21T16:00:01.361647","updated":"2024-11-21T16:00:01.361655","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e91557d9-cb8f-4a6f-b38f-8b4f6e654b19\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e91557d9-cb8f-4a6f-b38f-8b4f6e654b19/pipeline.log\">pipeline</a>"]},{"id":"d13ea1c8-d7c3-4b6a-856e-6b18a4435b00","name":"Fedora - 20","status":"complete","outcome":"error","runTime":1527.10127,"created":"2024-11-21T15:46:43.803608","updated":"2024-11-21T15:46:43.803616","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d13ea1c8-d7c3-4b6a-856e-6b18a4435b00\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d13ea1c8-d7c3-4b6a-856e-6b18a4435b00/pipeline.log\">pipeline</a>"]},{"id":"b65ea1f0-0a2f-479b-aeff-462ed7674590","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":1438.688538,"created":"2024-11-21T15:46:12.846975","updated":"2024-11-21T15:46:12.846986","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b65ea1f0-0a2f-479b-aeff-462ed7674590\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b65ea1f0-0a2f-479b-aeff-462ed7674590/pipeline.log\">pipeline</a>"]},{"id":"a9dc8f40-4e91-4517-87c6-061d84eb98d8","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":1543.603295,"created":"2024-11-21T15:48:03.338532","updated":"2024-11-21T15:48:03.338541","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a9dc8f40-4e91-4517-87c6-061d84eb98d8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a9dc8f40-4e91-4517-87c6-061d84eb98d8/pipeline.log\">pipeline</a>"]},{"id":"72f2a1fe-0768-482f-99d4-c70026cd6630","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":1640.426614,"created":"2024-11-21T15:48:30.123776","updated":"2024-11-21T15:48:30.123784","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/72f2a1fe-0768-482f-99d4-c70026cd6630\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/72f2a1fe-0768-482f-99d4-c70026cd6630/pipeline.log\">pipeline</a>"]},{"id":"2efcdbd5-0a8c-4675-ad45-e3e276988d47","name":"RHEL9 - 20","status":"complete","outcome":"error","runTime":2414.205845,"created":"2024-11-21T15:47:32.206969","updated":"2024-11-21T15:47:32.206976","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2efcdbd5-0a8c-4675-ad45-e3e276988d47\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2efcdbd5-0a8c-4675-ad45-e3e276988d47/pipeline.log\">pipeline</a>"]},{"id":"52642d15-1456-4193-b422-2387b2a52f3b","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":2775.28217,"created":"2024-11-21T15:49:06.748544","updated":"2024-11-21T15:49:06.748552","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/52642d15-1456-4193-b422-2387b2a52f3b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/52642d15-1456-4193-b422-2387b2a52f3b/pipeline.log\">pipeline</a>"]},{"id":"126bcef1-0d02-4b42-bd05-592f29b1c913","name":"RHEL9 - 18-minimal","status":"complete","outcome":"error","runTime":2267.693938,"created":"2024-11-21T15:44:31.236940","updated":"2024-11-21T15:44:31.236947","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/126bcef1-0d02-4b42-bd05-592f29b1c913\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/126bcef1-0d02-4b42-bd05-592f29b1c913/pipeline.log\">pipeline</a>"]},{"id":"dab43451-d413-4b0a-9317-98137d688f49","name":"RHEL9 - 18","status":"complete","outcome":"error","runTime":1310.583779,"created":"2024-11-21T15:28:23.181481","updated":"2024-11-21T15:28:23.181489","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dab43451-d413-4b0a-9317-98137d688f49\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dab43451-d413-4b0a-9317-98137d688f49/pipeline.log\">pipeline</a>"]},{"id":"64ad88c4-13de-4502-922d-25bebeaa8552","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":2207.882524,"created":"2024-11-21T15:44:30.463888","updated":"2024-11-21T15:44:30.463895","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/64ad88c4-13de-4502-922d-25bebeaa8552\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/64ad88c4-13de-4502-922d-25bebeaa8552/pipeline.log\">pipeline</a>"]},{"id":"6fe26a17-3000-427e-abfa-8f08a70a714a","name":"RHEL8 - 18","status":"complete","outcome":"passed","runTime":1309.029285,"created":"2024-11-21T15:27:40.125249","updated":"2024-11-21T15:27:40.125258","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6fe26a17-3000-427e-abfa-8f08a70a714a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6fe26a17-3000-427e-abfa-8f08a70a714a/pipeline.log\">pipeline</a>"]},{"id":"c7594fec-b4e2-4b3e-9a83-4ef590697883","name":"RHEL9 - 22-minimal","status":"complete","outcome":"error","runTime":1656.058863,"created":"2024-11-21T16:09:58.224169","updated":"2024-11-21T16:09:58.224177","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c7594fec-b4e2-4b3e-9a83-4ef590697883\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c7594fec-b4e2-4b3e-9a83-4ef590697883/pipeline.log\">pipeline</a>"]},{"id":"82995ff1-58dc-46f3-9170-f52fae5c7a5f","name":"RHEL9 - 22","status":"complete","outcome":"error","runTime":2392.869329,"created":"2024-11-21T16:03:08.589548","updated":"2024-11-21T16:03:08.589557","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/82995ff1-58dc-46f3-9170-f52fae5c7a5f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/82995ff1-58dc-46f3-9170-f52fae5c7a5f/pipeline.log\">pipeline</a>"]},{"id":"fdef5747-d0c3-4ce5-b93d-28c67e35318c","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":2374.56626,"created":"2024-11-21T15:46:54.272053","updated":"2024-11-21T15:46:54.272060","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fdef5747-d0c3-4ce5-b93d-28c67e35318c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fdef5747-d0c3-4ce5-b93d-28c67e35318c/pipeline.log\">pipeline</a>"]},{"id":"16017706-33b6-49a8-8ce3-09a49b42a25e","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":2772.10006,"created":"2024-11-21T15:49:02.744536","updated":"2024-11-21T15:49:02.744546","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/16017706-33b6-49a8-8ce3-09a49b42a25e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/16017706-33b6-49a8-8ce3-09a49b42a25e/pipeline.log\">pipeline</a>"]},{"id":"5704bcbc-b645-4ac9-be8c-3b9a253883fc","name":"RHEL9 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":4219.34581,"created":"2024-11-21T16:28:33.357270","updated":"2024-11-21T16:28:33.357277","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5704bcbc-b645-4ac9-be8c-3b9a253883fc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5704bcbc-b645-4ac9-be8c-3b9a253883fc/pipeline.log\">pipeline</a>"]},{"id":"054b2eb7-b467-4d33-8ee3-8c2e96097e3c","name":"RHEL8 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1633.231135,"created":"2024-11-21T15:40:23.892509","updated":"2024-11-21T15:40:23.892518","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/054b2eb7-b467-4d33-8ee3-8c2e96097e3c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/054b2eb7-b467-4d33-8ee3-8c2e96097e3c/pipeline.log\">pipeline</a>"]}]} -->