### PR TITLE
adding langchain to test suite

### DIFF
--- a/test/run-upstream
+++ b/test/run-upstream
@@ -26,6 +26,7 @@ test_client_faas
 test_client_cloudevents
 test_client_fastify
 test_client_pino
+test_client_langchain
 "
 
 readonly EXPRESS_REVISION="${EXPRESS_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show express version)}"
@@ -44,6 +45,8 @@ readonly CLOUDEVENTS_REVISION="v${CLOUDEVENTS_REVISION:-$(docker run --rm "${IMA
 readonly CLOUDEVENTS_REPO="https://github.com/cloudevents/sdk-javascript.git"
 readonly FASTIFY_REVISION="v${FASTIFY_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show fastify version)}"
 readonly FASTIFY_REPO="https://github.com/fastify/fastify.git"
+readonly LANGCHAIN_REVISION=v"${LANGCHAIN_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show langchain version)}"
+readonly LANGCHAIN_REPO="https://github.com/langchain-ai/langchainjs"
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from a registry


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

This PR adds the [langchain.js](https://www.npmjs.com/package/langchain) to the test suite.

<!-- issue-commentator = {"comment-id":"2513855501"} -->











































































































































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2517008389","data":[{"id":"e8c351de-823a-4775-9d0d-90a873c172c8","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":632.265181,"created":"2024-12-09T08:35:41.359670","updated":"2024-12-09T08:35:41.359678","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e8c351de-823a-4775-9d0d-90a873c172c8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e8c351de-823a-4775-9d0d-90a873c172c8/pipeline.log\">pipeline</a>"]},{"id":"def582db-50fd-4978-ad65-ff37cdcfada2","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":543.554622,"created":"2024-12-09T08:35:47.305234","updated":"2024-12-09T08:35:47.305242","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/def582db-50fd-4978-ad65-ff37cdcfada2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/def582db-50fd-4978-ad65-ff37cdcfada2/pipeline.log\">pipeline</a>"]},{"id":"e1199e8a-f405-4f3c-87b5-3e4232ae55be","name":"Fedora - 18-minimal","status":"complete","outcome":"passed","runTime":693.397391,"created":"2024-12-09T08:35:33.707825","updated":"2024-12-09T08:35:33.707833","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e1199e8a-f405-4f3c-87b5-3e4232ae55be\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e1199e8a-f405-4f3c-87b5-3e4232ae55be/pipeline.log\">pipeline</a>"]},{"id":"5a5e70e6-bdf2-4238-8838-5940df39f6fa","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":596.11829,"created":"2024-12-09T08:36:03.449147","updated":"2024-12-09T08:36:03.449157","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5a5e70e6-bdf2-4238-8838-5940df39f6fa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5a5e70e6-bdf2-4238-8838-5940df39f6fa/pipeline.log\">pipeline</a>"]},{"id":"014397c7-3348-4dc0-97cf-1097df09f4a6","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":973.929723,"created":"2024-12-09T08:35:32.735082","updated":"2024-12-09T08:35:32.735091","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/014397c7-3348-4dc0-97cf-1097df09f4a6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/014397c7-3348-4dc0-97cf-1097df09f4a6/pipeline.log\">pipeline</a>"]},{"id":"fd95c0cf-b4be-4f26-bc85-5665d9440b8b","name":"Fedora - 18","status":"complete","outcome":"passed","runTime":871.12099,"created":"2024-12-09T08:35:31.509967","updated":"2024-12-09T08:35:31.509977","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fd95c0cf-b4be-4f26-bc85-5665d9440b8b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fd95c0cf-b4be-4f26-bc85-5665d9440b8b/pipeline.log\">pipeline</a>"]},{"id":"71e96935-64d8-484f-bea1-2458df0ab264","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":879.280568,"created":"2024-12-09T08:35:40.812580","updated":"2024-12-09T08:35:40.812586","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/71e96935-64d8-484f-bea1-2458df0ab264\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/71e96935-64d8-484f-bea1-2458df0ab264/pipeline.log\">pipeline</a>"]},{"id":"7e033ee4-fafb-4aca-bdbd-b7399ea97a3f","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":1123.18818,"created":"2024-12-09T08:35:33.055411","updated":"2024-12-09T08:35:33.055420","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7e033ee4-fafb-4aca-bdbd-b7399ea97a3f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7e033ee4-fafb-4aca-bdbd-b7399ea97a3f/pipeline.log\">pipeline</a>"]},{"id":"fdda4ce6-c07d-4176-aa8c-053da83dc806","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":1007.140475,"created":"2024-12-09T08:35:33.902676","updated":"2024-12-09T08:35:33.902684","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fdda4ce6-c07d-4176-aa8c-053da83dc806\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fdda4ce6-c07d-4176-aa8c-053da83dc806/pipeline.log\">pipeline</a>"]},{"id":"4a60fa1d-843b-4f78-a824-6879d8b1189e","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":1138.952655,"created":"2024-12-09T08:35:33.336335","updated":"2024-12-09T08:35:33.336344","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4a60fa1d-843b-4f78-a824-6879d8b1189e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4a60fa1d-843b-4f78-a824-6879d8b1189e/pipeline.log\">pipeline</a>"]},{"id":"81d7540b-976e-48eb-9c04-71bfdff63a89","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1501.487772,"created":"2024-12-09T11:55:39.022827","updated":"2024-12-09T11:55:39.022834","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/81d7540b-976e-48eb-9c04-71bfdff63a89\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/81d7540b-976e-48eb-9c04-71bfdff63a89/pipeline.log\">pipeline</a>"]},{"id":"b684c985-4310-4241-b5a9-ae9dd4c36a19","name":"RHEL9 - 18-minimal","status":"complete","outcome":"passed","runTime":918.897919,"created":"2024-12-09T08:35:37.157498","updated":"2024-12-09T08:35:37.157506","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b684c985-4310-4241-b5a9-ae9dd4c36a19\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b684c985-4310-4241-b5a9-ae9dd4c36a19/pipeline.log\">pipeline</a>"]},{"id":"a8daf7a7-1c31-4f2b-81a0-9297b6a5c7ab","name":"RHEL9 - 18","status":"complete","outcome":"passed","runTime":1080.764793,"created":"2024-12-09T08:35:32.449518","updated":"2024-12-09T08:35:32.449525","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8daf7a7-1c31-4f2b-81a0-9297b6a5c7ab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a8daf7a7-1c31-4f2b-81a0-9297b6a5c7ab/pipeline.log\">pipeline</a>"]},{"id":"29ae7c22-262f-4944-8685-1b3bdded4b99","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":1123.62938,"created":"2024-12-09T08:35:33.722812","updated":"2024-12-09T08:35:33.722820","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/29ae7c22-262f-4944-8685-1b3bdded4b99\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/29ae7c22-262f-4944-8685-1b3bdded4b99/pipeline.log\">pipeline</a>"]},{"id":"3264d2d5-0fbd-4178-9e50-bbedf2f75d62","name":"RHEL8 - 18","status":"complete","outcome":"error","runTime":1372.182438,"created":"2024-12-09T11:55:46.333763","updated":"2024-12-09T11:55:46.333772","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3264d2d5-0fbd-4178-9e50-bbedf2f75d62\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3264d2d5-0fbd-4178-9e50-bbedf2f75d62/pipeline.log\">pipeline</a>"]},{"id":"3fd49d77-bfba-4a73-b1f6-6467fb33a16b","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1330.453507,"created":"2024-12-09T08:35:35.522295","updated":"2024-12-09T08:35:35.522304","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3fd49d77-bfba-4a73-b1f6-6467fb33a16b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3fd49d77-bfba-4a73-b1f6-6467fb33a16b/pipeline.log\">pipeline</a>"]},{"id":"698e61e9-1664-49f3-b5b6-2c4661e97a0f","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":995.851143,"created":"2024-12-09T08:36:13.596258","updated":"2024-12-09T08:36:13.596267","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/698e61e9-1664-49f3-b5b6-2c4661e97a0f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/698e61e9-1664-49f3-b5b6-2c4661e97a0f/pipeline.log\">pipeline</a>"]},{"id":"2771462b-6889-4143-88cd-e9f7c4f99841","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1188.524749,"created":"2024-12-09T08:35:52.308595","updated":"2024-12-09T08:35:52.308603","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2771462b-6889-4143-88cd-e9f7c4f99841\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2771462b-6889-4143-88cd-e9f7c4f99841/pipeline.log\">pipeline</a>"]},{"id":"0e9e0704-36de-4a35-843b-38aa0e0944d5","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1763.175089,"created":"2024-12-09T08:35:43.222207","updated":"2024-12-09T08:35:43.222213","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e9e0704-36de-4a35-843b-38aa0e0944d5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e9e0704-36de-4a35-843b-38aa0e0944d5/pipeline.log\">pipeline</a>"]},{"id":"4c1471cf-b75f-46bc-ac27-e45ed61f86be","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":1777.91015,"created":"2024-12-09T08:35:32.652067","updated":"2024-12-09T08:35:32.652077","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4c1471cf-b75f-46bc-ac27-e45ed61f86be\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4c1471cf-b75f-46bc-ac27-e45ed61f86be/pipeline.log\">pipeline</a>"]},{"id":"c020c7c9-85d3-494c-bb6f-394c0439420a","name":"RHEL8 - OpenShift 4 - 18-minimal","status":"complete","outcome":"error","runTime":6075.601831,"created":"2024-12-04T11:18:32.543191","updated":"2024-12-04T11:18:32.543199","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c020c7c9-85d3-494c-bb6f-394c0439420a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c020c7c9-85d3-494c-bb6f-394c0439420a/pipeline.log\">pipeline</a>"]},{"id":"fd081c2d-c6bf-4811-a567-0241fdfabde2","name":"RHEL9 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":6700.766818,"created":"2024-12-04T11:10:57.560014","updated":"2024-12-04T11:10:57.560021","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd081c2d-c6bf-4811-a567-0241fdfabde2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd081c2d-c6bf-4811-a567-0241fdfabde2/pipeline.log\">pipeline</a>"]},{"id":"5ef98f4e-cc7c-4bfd-9b21-7ba8f229fa47","name":"RHEL8 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":837.755922,"created":"2024-12-09T09:26:48.121994","updated":"2024-12-09T09:26:48.122002","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ef98f4e-cc7c-4bfd-9b21-7ba8f229fa47\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ef98f4e-cc7c-4bfd-9b21-7ba8f229fa47/pipeline.log\">pipeline</a>"]},{"id":"5e7fc8e7-3008-41c0-8817-c623ba47c1d5","name":"RHEL8 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":6930.84594,"created":"2024-12-04T11:10:45.976455","updated":"2024-12-04T11:10:45.976462","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e7fc8e7-3008-41c0-8817-c623ba47c1d5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e7fc8e7-3008-41c0-8817-c623ba47c1d5/pipeline.log\">pipeline</a>"]},{"id":"0d631593-5c76-424e-9ab7-f79e439331f8","name":"RHEL9 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":6538.976466,"created":"2024-12-04T11:19:29.593861","updated":"2024-12-04T11:19:29.593867","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d631593-5c76-424e-9ab7-f79e439331f8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d631593-5c76-424e-9ab7-f79e439331f8/pipeline.log\">pipeline</a>"]},{"id":"18da7997-c0ec-42d8-b5ea-370d53b9ca67","name":"RHEL9 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":698.970494,"created":"2024-12-09T09:26:48.660156","updated":"2024-12-09T09:26:48.660165","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/18da7997-c0ec-42d8-b5ea-370d53b9ca67\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/18da7997-c0ec-42d8-b5ea-370d53b9ca67/pipeline.log\">pipeline</a>"]},{"id":"ddb4befc-f4d6-4e12-b2c9-3a2bf2af564b","name":"RHEL8 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":6673.626132,"created":"2024-12-04T11:18:47.114781","updated":"2024-12-04T11:18:47.114788","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ddb4befc-f4d6-4e12-b2c9-3a2bf2af564b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ddb4befc-f4d6-4e12-b2c9-3a2bf2af564b/pipeline.log\">pipeline</a>"]},{"id":"091dcc96-24f8-4d15-a4fa-ed4e1446a4bb","name":"RHEL9 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":6621.450452,"created":"2024-12-04T11:19:53.581040","updated":"2024-12-04T11:19:53.581047","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/091dcc96-24f8-4d15-a4fa-ed4e1446a4bb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/091dcc96-24f8-4d15-a4fa-ed4e1446a4bb/pipeline.log\">pipeline</a>"]},{"id":"dd056539-7fae-4a0b-bbb8-00bdca7f756d","name":"RHEL9 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":6503.903788,"created":"2024-12-04T11:23:05.069071","updated":"2024-12-04T11:23:05.069078","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dd056539-7fae-4a0b-bbb8-00bdca7f756d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dd056539-7fae-4a0b-bbb8-00bdca7f756d/pipeline.log\">pipeline</a>"]},{"id":"2350df03-9b71-414b-9ca0-458d8076e011","name":"RHEL8 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":6740.215493,"created":"2024-12-04T11:20:21.849166","updated":"2024-12-04T11:20:21.849174","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2350df03-9b71-414b-9ca0-458d8076e011\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2350df03-9b71-414b-9ca0-458d8076e011/pipeline.log\">pipeline</a>"]},{"id":"6aef3238-9e76-4746-88c7-36045db10922","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":838.289683,"created":"2024-12-09T09:26:48.938380","updated":"2024-12-09T09:26:48.938388","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6aef3238-9e76-4746-88c7-36045db10922\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6aef3238-9e76-4746-88c7-36045db10922/pipeline.log\">pipeline</a>"]},{"id":"ebdf8d0d-6ce3-46fb-81d4-427b2d790a25","name":"RHEL8 - PyTest - OpenShift 4 - 18","runTime":1893.78191,"created":"2024-12-09T12:12:56.278755","updated":"2024-12-09T12:12:56.278764","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebdf8d0d-6ce3-46fb-81d4-427b2d790a25\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebdf8d0d-6ce3-46fb-81d4-427b2d790a25/pipeline.log\">pipeline</a>"]},{"id":"d915ce6b-db70-412c-bad7-20a5642e4081","name":"RHEL9 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":758.095154,"created":"2024-12-09T09:26:48.481016","updated":"2024-12-09T09:26:48.481025","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d915ce6b-db70-412c-bad7-20a5642e4081\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d915ce6b-db70-412c-bad7-20a5642e4081/pipeline.log\">pipeline</a>"]},{"id":"0cfa6c96-a680-4268-ae11-80b9d8740e1d","name":"RHEL9 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"error","runTime":1712.825151,"created":"2024-12-09T12:12:56.446079","updated":"2024-12-09T12:12:56.446087","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0cfa6c96-a680-4268-ae11-80b9d8740e1d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0cfa6c96-a680-4268-ae11-80b9d8740e1d/pipeline.log\">pipeline</a>"]},{"id":"8eb22d73-352b-4f81-8854-16ddc2ad6f1a","name":"RHEL9 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":856.930307,"created":"2024-12-09T09:26:48.131992","updated":"2024-12-09T09:26:48.132000","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8eb22d73-352b-4f81-8854-16ddc2ad6f1a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8eb22d73-352b-4f81-8854-16ddc2ad6f1a/pipeline.log\">pipeline</a>"]},{"id":"c42debb4-b328-4dfe-a747-80a1d5304066","name":"RHEL9 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":872.545184,"created":"2024-12-09T09:26:51.193691","updated":"2024-12-09T09:26:51.193700","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c42debb4-b328-4dfe-a747-80a1d5304066\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c42debb4-b328-4dfe-a747-80a1d5304066/pipeline.log\">pipeline</a>"]},{"id":"150a5a70-54bb-458e-9e89-52f50ecfd6b5","name":"RHEL9 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"error","runTime":1801.946149,"created":"2024-12-09T12:12:59.941901","updated":"2024-12-09T12:12:59.941908","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/150a5a70-54bb-458e-9e89-52f50ecfd6b5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/150a5a70-54bb-458e-9e89-52f50ecfd6b5/pipeline.log\">pipeline</a>"]},{"id":"0dad7810-c936-4eec-9ded-7ca371d7c9af","name":"RHEL8 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1123.783977,"created":"2024-12-09T12:12:56.357532","updated":"2024-12-09T12:12:56.357542","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0dad7810-c936-4eec-9ded-7ca371d7c9af\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0dad7810-c936-4eec-9ded-7ca371d7c9af/pipeline.log\">pipeline</a>"]},{"id":"012b7e51-c7a0-41f2-abbc-10482c2de7c8","name":"RHEL8 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"error","runTime":1730.338324,"created":"2024-12-09T12:12:57.364629","updated":"2024-12-09T12:12:57.364639","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/012b7e51-c7a0-41f2-abbc-10482c2de7c8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/012b7e51-c7a0-41f2-abbc-10482c2de7c8/pipeline.log\">pipeline</a>"]},{"id":"161a1b92-0587-4dcb-95e0-613258fa5d18","name":"RHEL8 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1011.720283,"created":"2024-12-09T09:26:51.640863","updated":"2024-12-09T09:26:51.640872","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/161a1b92-0587-4dcb-95e0-613258fa5d18\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/161a1b92-0587-4dcb-95e0-613258fa5d18/pipeline.log\">pipeline</a>"]}]} -->