### PR TITLE
Before stopping and removing cid_file. Check if it is present

### DIFF
--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -186,8 +186,10 @@ run_client_test_suite() {
 }
 
 kill_test_application() {
-	docker stop $(cat $cid_file)
-	rm $cid_file
+  docker stop $(cat $cid_file)
+  if [[ -f "$cid_file" ]]; then
+    rm "$cid_file"
+  fi
 }
 
 wait_for_cid() {


### PR DESCRIPTION
In case of cid_file is not present, then do no remove cid_file






































<!-- issue-commentator = {"comment-id":"2517433645"} -->

































































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2517369109","data":[{"id":"778a0afc-ef38-4cd1-8795-0615e3ec3c8f","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":1466.278171,"created":"2024-12-04T13:04:12.123806","updated":"2024-12-04T13:04:12.123813","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/778a0afc-ef38-4cd1-8795-0615e3ec3c8f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/778a0afc-ef38-4cd1-8795-0615e3ec3c8f/pipeline.log\">pipeline</a>"]},{"id":"3fcfcecf-67cc-4526-805f-c940a04537c1","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":1409.22148,"created":"2024-12-04T13:06:46.910937","updated":"2024-12-04T13:06:46.910945","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3fcfcecf-67cc-4526-805f-c940a04537c1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3fcfcecf-67cc-4526-805f-c940a04537c1/pipeline.log\">pipeline</a>"]},{"id":"78af426c-6d84-4fbf-8731-7a1619403e60","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":544.36583,"created":"2024-12-05T10:14:00.574080","updated":"2024-12-05T10:14:00.574088","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/78af426c-6d84-4fbf-8731-7a1619403e60\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/78af426c-6d84-4fbf-8731-7a1619403e60/pipeline.log\">pipeline</a>"]},{"id":"02c34c70-f045-4eae-922e-a5f8b2a6f8bc","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":1210.301872,"created":"2024-12-05T07:41:32.460503","updated":"2024-12-05T07:41:32.460509","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/02c34c70-f045-4eae-922e-a5f8b2a6f8bc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/02c34c70-f045-4eae-922e-a5f8b2a6f8bc/pipeline.log\">pipeline</a>"]},{"id":"01d9c520-893b-4ca7-8ad5-49bbe15bb5d6","name":"RHEL9 - 18","status":"complete","outcome":"passed","runTime":1089.431982,"created":"2024-12-05T07:41:32.423028","updated":"2024-12-05T07:41:32.423036","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01d9c520-893b-4ca7-8ad5-49bbe15bb5d6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01d9c520-893b-4ca7-8ad5-49bbe15bb5d6/pipeline.log\">pipeline</a>"]},{"id":"4cfad3ba-cfe5-4e06-bffe-1b7658394d53","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1263.468468,"created":"2024-12-05T07:41:32.272994","updated":"2024-12-05T07:41:32.273002","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4cfad3ba-cfe5-4e06-bffe-1b7658394d53\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4cfad3ba-cfe5-4e06-bffe-1b7658394d53/pipeline.log\">pipeline</a>"]},{"id":"2be4310c-8e10-437b-9a93-01b40aed4668","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":1920.022001,"created":"2024-12-04T13:09:23.944012","updated":"2024-12-04T13:09:23.944023","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2be4310c-8e10-437b-9a93-01b40aed4668\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2be4310c-8e10-437b-9a93-01b40aed4668/pipeline.log\">pipeline</a>"]},{"id":"1c4a0b50-d74f-4711-9278-39d539e1948c","name":"Fedora - 18-minimal","status":"complete","outcome":"passed","runTime":1655.07563,"created":"2024-12-04T13:14:12.753778","updated":"2024-12-04T13:14:12.753787","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1c4a0b50-d74f-4711-9278-39d539e1948c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1c4a0b50-d74f-4711-9278-39d539e1948c/pipeline.log\">pipeline</a>"]},{"id":"2294b983-09ee-4ad2-b5ac-97c230c8f570","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":1733.255867,"created":"2024-12-05T07:41:31.989601","updated":"2024-12-05T07:41:31.989608","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2294b983-09ee-4ad2-b5ac-97c230c8f570\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2294b983-09ee-4ad2-b5ac-97c230c8f570/pipeline.log\">pipeline</a>"]},{"id":"092c9993-e343-44dd-ad08-07bcd76d79ba","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1210.649036,"created":"2024-12-05T07:41:32.426672","updated":"2024-12-05T07:41:32.426680","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/092c9993-e343-44dd-ad08-07bcd76d79ba\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/092c9993-e343-44dd-ad08-07bcd76d79ba/pipeline.log\">pipeline</a>"]},{"id":"f85f57db-a28d-42a4-9846-f6c555440d84","name":"Fedora - 18","status":"complete","outcome":"passed","runTime":1780.07765,"created":"2024-12-04T13:13:15.693518","updated":"2024-12-04T13:13:15.693527","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f85f57db-a28d-42a4-9846-f6c555440d84\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f85f57db-a28d-42a4-9846-f6c555440d84/pipeline.log\">pipeline</a>"]},{"id":"50aa687c-d060-4c87-92a1-924ebf524498","name":"RHEL9 - 18-minimal","status":"complete","outcome":"passed","runTime":1016.385026,"created":"2024-12-05T07:41:34.386686","updated":"2024-12-05T07:41:34.386693","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/50aa687c-d060-4c87-92a1-924ebf524498\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/50aa687c-d060-4c87-92a1-924ebf524498/pipeline.log\">pipeline</a>"]},{"id":"10f7bcdd-9c7e-4d79-a7d8-27ece6e530eb","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1346.751268,"created":"2024-12-05T07:41:32.337922","updated":"2024-12-05T07:41:32.337928","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/10f7bcdd-9c7e-4d79-a7d8-27ece6e530eb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/10f7bcdd-9c7e-4d79-a7d8-27ece6e530eb/pipeline.log\">pipeline</a>"]},{"id":"1524e5d7-1d9b-45ff-b6e2-09695c5cccba","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":605.883738,"created":"2024-12-05T10:14:02.359584","updated":"2024-12-05T10:14:02.359591","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1524e5d7-1d9b-45ff-b6e2-09695c5cccba\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1524e5d7-1d9b-45ff-b6e2-09695c5cccba/pipeline.log\">pipeline</a>"]},{"id":"cb0a6602-4026-496d-97fd-8b592adaa99c","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":1270.045831,"created":"2024-12-04T13:39:22.647272","updated":"2024-12-04T13:39:22.647280","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cb0a6602-4026-496d-97fd-8b592adaa99c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cb0a6602-4026-496d-97fd-8b592adaa99c/pipeline.log\">pipeline</a>"]},{"id":"e82062b3-e436-41a3-a2b9-6d778cb58867","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":1358.891823,"created":"2024-12-04T13:38:51.458629","updated":"2024-12-04T13:38:51.458638","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e82062b3-e436-41a3-a2b9-6d778cb58867\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e82062b3-e436-41a3-a2b9-6d778cb58867/pipeline.log\">pipeline</a>"]},{"id":"f40e7052-a897-40c1-95d6-31cd1001170c","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":1808.060732,"created":"2024-12-04T13:38:55.103569","updated":"2024-12-04T13:38:55.103577","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f40e7052-a897-40c1-95d6-31cd1001170c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f40e7052-a897-40c1-95d6-31cd1001170c/pipeline.log\">pipeline</a>"]},{"id":"b6d685bf-4b95-4ab9-8fdf-52679061dd74","name":"RHEL8 - 18","status":"complete","outcome":"passed","runTime":2113.758543,"created":"2024-12-04T13:38:41.450337","updated":"2024-12-04T13:38:41.450344","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6d685bf-4b95-4ab9-8fdf-52679061dd74\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6d685bf-4b95-4ab9-8fdf-52679061dd74/pipeline.log\">pipeline</a>"]},{"id":"ace4cb0b-62bc-4122-9251-2523e5246fa4","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":1018.605803,"created":"2024-12-05T07:41:33.642472","updated":"2024-12-05T07:41:33.642478","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ace4cb0b-62bc-4122-9251-2523e5246fa4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ace4cb0b-62bc-4122-9251-2523e5246fa4/pipeline.log\">pipeline</a>"]},{"id":"3f1445f5-5a62-4e03-80fa-14e5ea63334b","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1572.538859,"created":"2024-12-05T07:41:32.410718","updated":"2024-12-05T07:41:32.410726","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f1445f5-5a62-4e03-80fa-14e5ea63334b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3f1445f5-5a62-4e03-80fa-14e5ea63334b/pipeline.log\">pipeline</a>"]},{"id":"55cfd051-333d-4245-a038-1f5982f6dbe2","name":"RHEL9 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":711.582942,"created":"2024-12-05T11:05:16.856479","updated":"2024-12-05T11:05:16.856486","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/55cfd051-333d-4245-a038-1f5982f6dbe2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/55cfd051-333d-4245-a038-1f5982f6dbe2/pipeline.log\">pipeline</a>"]},{"id":"01f33b23-c10b-4d80-a8dd-e97739bb7af3","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":929.238868,"created":"2024-12-05T11:02:56.212547","updated":"2024-12-05T11:02:56.212556","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01f33b23-c10b-4d80-a8dd-e97739bb7af3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01f33b23-c10b-4d80-a8dd-e97739bb7af3/pipeline.log\">pipeline</a>"]},{"id":"f1b7dd72-6a4a-4cad-9458-c0e3990c28b1","name":"RHEL9 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":768.296357,"created":"2024-12-06T08:02:53.784080","updated":"2024-12-06T08:02:53.784087","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1b7dd72-6a4a-4cad-9458-c0e3990c28b1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1b7dd72-6a4a-4cad-9458-c0e3990c28b1/pipeline.log\">pipeline</a>"]},{"id":"12929a14-d8df-4f4e-943b-273916a354b6","name":"RHEL8 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":807.274731,"created":"2024-12-05T11:05:17.390580","updated":"2024-12-05T11:05:17.390587","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/12929a14-d8df-4f4e-943b-273916a354b6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/12929a14-d8df-4f4e-943b-273916a354b6/pipeline.log\">pipeline</a>"]},{"id":"43221257-bc15-40c5-9a57-c69caa868a3c","name":"RHEL9 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1570.000054,"created":"2024-12-05T11:02:55.149480","updated":"2024-12-05T11:02:55.149488","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/43221257-bc15-40c5-9a57-c69caa868a3c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/43221257-bc15-40c5-9a57-c69caa868a3c/pipeline.log\">pipeline</a>"]},{"id":"a2077d25-b4b3-45b5-9c4d-cd4ea78853f3","name":"RHEL8 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1082.811118,"created":"2024-12-05T11:13:25.649880","updated":"2024-12-05T11:13:25.649887","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2077d25-b4b3-45b5-9c4d-cd4ea78853f3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2077d25-b4b3-45b5-9c4d-cd4ea78853f3/pipeline.log\">pipeline</a>"]},{"id":"b2d16f65-850d-4754-8bd3-14decfbf30ab","name":"RHEL9 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":919.680158,"created":"2024-12-05T11:16:25.302272","updated":"2024-12-05T11:16:25.302282","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2d16f65-850d-4754-8bd3-14decfbf30ab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b2d16f65-850d-4754-8bd3-14decfbf30ab/pipeline.log\">pipeline</a>"]},{"id":"96e60af3-9d25-4ab2-b770-bd78c404b657","name":"RHEL9 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1806.99668,"created":"2024-12-05T11:02:55.669206","updated":"2024-12-05T11:02:55.669214","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/96e60af3-9d25-4ab2-b770-bd78c404b657\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/96e60af3-9d25-4ab2-b770-bd78c404b657/pipeline.log\">pipeline</a>"]},{"id":"5c97ca9b-b38f-4190-b85a-47094e9be28d","name":"RHEL8 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1888.887053,"created":"2024-12-05T11:02:56.722889","updated":"2024-12-05T11:02:56.722896","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5c97ca9b-b38f-4190-b85a-47094e9be28d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5c97ca9b-b38f-4190-b85a-47094e9be28d/pipeline.log\">pipeline</a>"]},{"id":"f31fb451-798a-40eb-8255-5acadb3161cc","name":"RHEL9 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":914.999688,"created":"2024-12-05T11:19:08.391341","updated":"2024-12-05T11:19:08.391348","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f31fb451-798a-40eb-8255-5acadb3161cc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f31fb451-798a-40eb-8255-5acadb3161cc/pipeline.log\">pipeline</a>"]},{"id":"a5fe733c-c77b-49c5-8a4b-6e11f1a02228","name":"RHEL8 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1912.006621,"created":"2024-12-05T11:02:55.988077","updated":"2024-12-05T11:02:55.988087","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a5fe733c-c77b-49c5-8a4b-6e11f1a02228\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a5fe733c-c77b-49c5-8a4b-6e11f1a02228/pipeline.log\">pipeline</a>"]},{"id":"5ccb4bbc-5ed1-42c7-ba68-8a39569f251b","name":"RHEL8 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1923.754123,"created":"2024-12-05T11:02:58.032443","updated":"2024-12-05T11:02:58.032451","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ccb4bbc-5ed1-42c7-ba68-8a39569f251b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ccb4bbc-5ed1-42c7-ba68-8a39569f251b/pipeline.log\">pipeline</a>"]},{"id":"482d24bd-5c1e-4205-a37e-b0d4c2176707","name":"RHEL8 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1007.70345,"created":"2024-12-05T11:19:04.773411","updated":"2024-12-05T11:19:04.773419","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/482d24bd-5c1e-4205-a37e-b0d4c2176707\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/482d24bd-5c1e-4205-a37e-b0d4c2176707/pipeline.log\">pipeline</a>"]},{"id":"fa755415-3bcd-4dee-a43f-6177f5921df1","name":"RHEL9 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":2035.479138,"created":"2024-12-05T11:02:55.514925","updated":"2024-12-05T11:02:55.514934","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fa755415-3bcd-4dee-a43f-6177f5921df1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fa755415-3bcd-4dee-a43f-6177f5921df1/pipeline.log\">pipeline</a>"]},{"id":"e4aff62e-34a7-453e-9a0d-40291bc8d8af","name":"RHEL8 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":2149.675516,"created":"2024-12-05T11:02:56.183460","updated":"2024-12-05T11:02:56.183468","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e4aff62e-34a7-453e-9a0d-40291bc8d8af\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e4aff62e-34a7-453e-9a0d-40291bc8d8af/pipeline.log\">pipeline</a>"]},{"id":"5d61ed74-fba6-4736-9dd0-4c4c0f635a83","name":"RHEL9 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":2166.359071,"created":"2024-12-05T11:02:55.795446","updated":"2024-12-05T11:02:55.795454","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d61ed74-fba6-4736-9dd0-4c4c0f635a83\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5d61ed74-fba6-4736-9dd0-4c4c0f635a83/pipeline.log\">pipeline</a>"]},{"id":"65e803c8-2e1e-4a0b-87aa-c54d9e479c25","name":"RHEL9 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"error","runTime":1752.787866,"created":"2024-12-06T08:02:53.519211","updated":"2024-12-06T08:02:53.519220","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/65e803c8-2e1e-4a0b-87aa-c54d9e479c25\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/65e803c8-2e1e-4a0b-87aa-c54d9e479c25/pipeline.log\">pipeline</a>"]},{"id":"da73b696-e8bd-4625-91ca-97007ee8d57e","name":"RHEL8 - PyTest - OpenShift 4 - 20","runTime":2066.06992,"created":"2024-12-06T08:02:53.074915","updated":"2024-12-06T08:02:53.074923","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/da73b696-e8bd-4625-91ca-97007ee8d57e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/da73b696-e8bd-4625-91ca-97007ee8d57e/pipeline.log\">pipeline</a>"]},{"id":"fc62c09f-d365-4ef7-954f-4c4f8dd78c82","name":"RHEL8 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"error","runTime":1891.085185,"created":"2024-12-06T08:02:53.853172","updated":"2024-12-06T08:02:53.853184","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc62c09f-d365-4ef7-954f-4c4f8dd78c82\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc62c09f-d365-4ef7-954f-4c4f8dd78c82/pipeline.log\">pipeline</a>"]},{"id":"ce0564f9-4625-4c39-b3db-c1079b015d8e","name":"RHEL9 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"error","runTime":1640.06483,"created":"2024-12-06T08:02:53.034880","updated":"2024-12-06T08:02:53.034889","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ce0564f9-4625-4c39-b3db-c1079b015d8e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ce0564f9-4625-4c39-b3db-c1079b015d8e/pipeline.log\">pipeline</a>"]}]} -->