### PR TITLE
Add missing function for testing langchainjs

### DIFF
--- a/test/run-upstream
+++ b/test/run-upstream
@@ -26,7 +26,7 @@ test_client_faas
 test_client_cloudevents
 test_client_fastify
 test_client_pino
-test_client_langchain
+test_client_langchainjs
 "
 
 readonly EXPRESS_REVISION="${EXPRESS_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show express version)}"
@@ -45,8 +45,8 @@ readonly CLOUDEVENTS_REVISION="v${CLOUDEVENTS_REVISION:-$(docker run --rm "${IMA
 readonly CLOUDEVENTS_REPO="https://github.com/cloudevents/sdk-javascript.git"
 readonly FASTIFY_REVISION="v${FASTIFY_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show fastify version)}"
 readonly FASTIFY_REPO="https://github.com/fastify/fastify.git"
-readonly LANGCHAIN_REVISION=v"${LANGCHAIN_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show langchain version)}"
-readonly LANGCHAIN_REPO="https://github.com/langchain-ai/langchainjs"
+readonly LANGCHAINJS_REVISION="${LANGCHAINJS_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show langchain version)}"
+readonly LANGCHAINJS_REPO="https://github.com/langchain-ai/langchainjs.git"
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from a registry

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -448,6 +448,12 @@ function test_client_cloudevents() {
   echo "Running CloudEvents client test"
   test_running_client_js cloudevents
 }
+
+function test_client_langchainjs() {
+  echo "Running langchainjs client test"
+  test_running_client_js langchainjs
+}
+
 function test_client_fastify() {
   if [[ "${VERSION}" == *"minimal"* ]]; then
     VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)


### PR DESCRIPTION
Add missing function for testing langchainjs

The revision was added with 'v' prefix, but upstream
repository do not use it.

This pull request fixes bug introduced by https://github.com/sclorg/s2i-nodejs-container/pull/462

<!-- issue-commentator = {"comment-id":"2535508096"} -->





































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2535534225","data":[{"id":"b13ff6c7-bcbe-48ff-a0e5-9c2d0a635199","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":591.837862,"created":"2024-12-11T11:36:53.898536","updated":"2024-12-11T11:36:53.898545","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b13ff6c7-bcbe-48ff-a0e5-9c2d0a635199\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b13ff6c7-bcbe-48ff-a0e5-9c2d0a635199/pipeline.log\">pipeline</a>"]},{"id":"cf73a6bf-0170-4604-a7c9-64e2c48de247","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":580.656306,"created":"2024-12-11T11:37:52.298972","updated":"2024-12-11T11:37:52.298980","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cf73a6bf-0170-4604-a7c9-64e2c48de247\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cf73a6bf-0170-4604-a7c9-64e2c48de247/pipeline.log\">pipeline</a>"]},{"id":"27571617-aec5-49ce-ab81-3899b6f832ce","name":"Fedora - 18-minimal","status":"complete","outcome":"passed","runTime":654.841606,"created":"2024-12-11T11:36:43.702742","updated":"2024-12-11T11:36:43.702749","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/27571617-aec5-49ce-ab81-3899b6f832ce\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/27571617-aec5-49ce-ab81-3899b6f832ce/pipeline.log\">pipeline</a>"]},{"id":"b59df7fa-d6c4-4669-a7d4-4046db847fa6","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":615.426835,"created":"2024-12-11T11:36:51.901594","updated":"2024-12-11T11:36:51.901601","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b59df7fa-d6c4-4669-a7d4-4046db847fa6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b59df7fa-d6c4-4669-a7d4-4046db847fa6/pipeline.log\">pipeline</a>"]},{"id":"e852d44a-ca20-4bb4-ab8b-1d5923a00278","name":"Fedora - 18","status":"complete","outcome":"passed","runTime":816.560354,"created":"2024-12-11T11:36:45.112403","updated":"2024-12-11T11:36:45.112411","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e852d44a-ca20-4bb4-ab8b-1d5923a00278\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e852d44a-ca20-4bb4-ab8b-1d5923a00278/pipeline.log\">pipeline</a>"]},{"id":"c3669539-2c68-427d-ab7c-4cfb849a892f","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":927.146598,"created":"2024-12-11T11:36:52.221728","updated":"2024-12-11T11:36:52.221738","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c3669539-2c68-427d-ab7c-4cfb849a892f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c3669539-2c68-427d-ab7c-4cfb849a892f/pipeline.log\">pipeline</a>"]},{"id":"b88876c1-38a2-47b1-a97a-4b6bbb5b5970","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":1042.048042,"created":"2024-12-11T11:36:43.277846","updated":"2024-12-11T11:36:43.277854","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b88876c1-38a2-47b1-a97a-4b6bbb5b5970\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b88876c1-38a2-47b1-a97a-4b6bbb5b5970/pipeline.log\">pipeline</a>"]},{"id":"2dd7a143-2ffd-4718-94b7-a524b32263ef","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":913.61817,"created":"2024-12-11T11:36:43.775996","updated":"2024-12-11T11:36:43.776005","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2dd7a143-2ffd-4718-94b7-a524b32263ef\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2dd7a143-2ffd-4718-94b7-a524b32263ef/pipeline.log\">pipeline</a>"]},{"id":"ceb13f39-7434-491a-bce8-9a1b7562373a","name":"RHEL9 - 18-minimal","status":"complete","outcome":"passed","runTime":971.479608,"created":"2024-12-11T11:36:46.030285","updated":"2024-12-11T11:36:46.030293","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ceb13f39-7434-491a-bce8-9a1b7562373a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ceb13f39-7434-491a-bce8-9a1b7562373a/pipeline.log\">pipeline</a>"]},{"id":"2dcbd8a5-637f-4139-b93e-4f1fcdf93b88","name":"RHEL9 - 18","status":"complete","outcome":"passed","runTime":1205.127746,"created":"2024-12-11T11:36:42.284266","updated":"2024-12-11T11:36:42.284276","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2dcbd8a5-637f-4139-b93e-4f1fcdf93b88\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2dcbd8a5-637f-4139-b93e-4f1fcdf93b88/pipeline.log\">pipeline</a>"]},{"id":"81290dba-0674-45a9-98d3-099f1ea6cda7","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":1083.213709,"created":"2024-12-11T10:52:45.575240","updated":"2024-12-11T10:52:45.575248","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/81290dba-0674-45a9-98d3-099f1ea6cda7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/81290dba-0674-45a9-98d3-099f1ea6cda7/pipeline.log\">pipeline</a>"]},{"id":"9b7965a6-055d-4322-8759-f85c278998b9","name":"RHEL8 - 18","status":"complete","outcome":"passed","runTime":1177.494023,"created":"2024-12-11T11:36:43.056344","updated":"2024-12-11T11:36:43.056352","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b7965a6-055d-4322-8759-f85c278998b9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b7965a6-055d-4322-8759-f85c278998b9/pipeline.log\">pipeline</a>"]},{"id":"f402edfa-7424-4830-9d6a-1bd5b7524c0b","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":1163.796872,"created":"2024-12-11T11:36:44.786480","updated":"2024-12-11T11:36:44.786489","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f402edfa-7424-4830-9d6a-1bd5b7524c0b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f402edfa-7424-4830-9d6a-1bd5b7524c0b/pipeline.log\">pipeline</a>"]},{"id":"fd1f077f-83ff-475c-bf23-808935319554","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1220.567241,"created":"2024-12-11T11:36:43.514093","updated":"2024-12-11T11:36:43.514099","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd1f077f-83ff-475c-bf23-808935319554\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fd1f077f-83ff-475c-bf23-808935319554/pipeline.log\">pipeline</a>"]},{"id":"9c7e973d-8e41-4cd9-99c5-10c53399f7d2","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1243.610126,"created":"2024-12-11T11:36:51.711719","updated":"2024-12-11T11:36:51.711726","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c7e973d-8e41-4cd9-99c5-10c53399f7d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c7e973d-8e41-4cd9-99c5-10c53399f7d2/pipeline.log\">pipeline</a>"]},{"id":"171d3591-2a3f-4834-808c-35b1c467e77b","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":1182.057209,"created":"2024-12-11T11:36:54.518380","updated":"2024-12-11T11:36:54.518387","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/171d3591-2a3f-4834-808c-35b1c467e77b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/171d3591-2a3f-4834-808c-35b1c467e77b/pipeline.log\">pipeline</a>"]},{"id":"32dd1536-f6b7-469f-a854-c2e924bf1b55","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1355.075324,"created":"2024-12-11T11:36:45.602405","updated":"2024-12-11T11:36:45.602413","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/32dd1536-f6b7-469f-a854-c2e924bf1b55\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/32dd1536-f6b7-469f-a854-c2e924bf1b55/pipeline.log\">pipeline</a>"]},{"id":"0e41926e-2520-452d-8e10-d0c4d39a97d4","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1519.543656,"created":"2024-12-11T11:36:44.384603","updated":"2024-12-11T11:36:44.384611","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e41926e-2520-452d-8e10-d0c4d39a97d4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0e41926e-2520-452d-8e10-d0c4d39a97d4/pipeline.log\">pipeline</a>"]},{"id":"302748e7-5dd6-45f8-913e-d34aa8f7cf28","name":"RHEL8 - 20-minimal","runTime":1691.1185,"created":"2024-12-11T11:36:43.014564","updated":"2024-12-11T11:36:43.014573","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/302748e7-5dd6-45f8-913e-d34aa8f7cf28\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/302748e7-5dd6-45f8-913e-d34aa8f7cf28/pipeline.log\">pipeline</a>"]},{"id":"d124fd8a-2c13-470d-b0ae-a0ab35739b72","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":945.953325,"created":"2024-12-11T11:46:01.982581","updated":"2024-12-11T11:46:01.982590","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d124fd8a-2c13-470d-b0ae-a0ab35739b72\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d124fd8a-2c13-470d-b0ae-a0ab35739b72/pipeline.log\">pipeline</a>"]}]} -->