### PR TITLE
Fix Fedora NodeJS container so tests passed

### DIFF
--- a/22-minimal/Dockerfile.fedora
+++ b/22-minimal/Dockerfile.fedora
@@ -52,7 +52,7 @@ LABEL summary="$SUMMARY" \
 RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     microdnf clean all && \
-    rm /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
+    ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
     ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
     ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \

--- a/22/Dockerfile.fedora
+++ b/22/Dockerfile.fedora
@@ -51,9 +51,9 @@ LABEL summary="$SUMMARY" \
 RUN INSTALL_PKGS="make gcc gcc-c++ libatomic_ops git openssl-devel nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    rm /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
-    rm /usr/bin/npm && ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
-    rm /usr/bin/npx && ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
+    ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
+    ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
+    ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     dnf -y clean all --enablerepo='*'
 


### PR DESCRIPTION
NodeJS 22 Fedora container does not install nodejs package and therefore /usr/bin/node and the others are not present.

The commit is simple and fix the problem during build of NodeJS 22 and NodeJS 22-minimal container.
We do not install nodejs package that contains /usr/bin/node file and the rest.
Therefore build is failing.
This fixes the problem.
