### PR TITLE
Enable building and testing NodeJS containers in RHEL10 host.

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "18", "18-minimal", "20", "20-minimal", "22", "22-minimal" ]
-        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c9s", "c10s" ]
         test_case: [ "container" ]
 
     if: |

--- a/.github/workflows/openshift-pytests.yml
+++ b/.github/workflows/openshift-pytests.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "16", "16-minimal", "18", "18-minimal", "20", "20-minimal" ]
-        os_test: [ "rhel8", "rhel9"]
+        version: [ "16", "16-minimal", "18", "18-minimal", "20", "20-minimal", "22", "22-minimal" ]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-pytest" ]
 
     steps:

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -27,8 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "18", "18-minimal", "20", "20-minimal" ]
-        os_test: [ "rhel8", "rhel9"]
+        version: [ "18", "18-minimal", "20", "20-minimal", "22", "22-minimal" ]
+        os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-4" ]
 
     steps:


### PR DESCRIPTION
Enable building and testing NodeJS containers in RHEL10 host.
No code is changed.










<!-- issue-commentator = {"comment-id":"2603975692"} -->

















































































































<!-- testing-farm = {"lock":"false","comment-id":"2603975116","data":[{"id":"39c9a768-74e0-43f3-8fc1-d7f52b04500f","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":438.929807,"created":"2025-01-21T08:28:54.098699","updated":"2025-01-21T08:28:54.098707","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/39c9a768-74e0-43f3-8fc1-d7f52b04500f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/39c9a768-74e0-43f3-8fc1-d7f52b04500f/pipeline.log\">pipeline</a>"]},{"id":"1448d6e4-b4c3-483b-8820-7d58c02d7644","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":530.928711,"created":"2025-01-21T08:28:35.043806","updated":"2025-01-21T08:28:35.043812","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1448d6e4-b4c3-483b-8820-7d58c02d7644\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1448d6e4-b4c3-483b-8820-7d58c02d7644/pipeline.log\">pipeline</a>"]},{"id":"9237b07f-b26c-4c67-a47d-3c2295a69beb","name":"CentOS Stream 9 - 20","status":"complete","outcome":"error","runTime":539.38315,"created":"2025-01-21T08:28:34.324832","updated":"2025-01-21T08:28:34.324841","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9237b07f-b26c-4c67-a47d-3c2295a69beb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9237b07f-b26c-4c67-a47d-3c2295a69beb/pipeline.log\">pipeline</a>"]},{"id":"4aba4d9e-0acd-42ae-a9d3-b8a83c0b6f11","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":538.072541,"created":"2025-01-21T08:28:40.343995","updated":"2025-01-21T08:28:40.344001","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4aba4d9e-0acd-42ae-a9d3-b8a83c0b6f11\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4aba4d9e-0acd-42ae-a9d3-b8a83c0b6f11/pipeline.log\">pipeline</a>"]},{"id":"52fac423-d66b-4799-b95c-b6791d83efe5","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":600.93336,"created":"2025-01-21T08:28:34.501995","updated":"2025-01-21T08:28:34.502002","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/52fac423-d66b-4799-b95c-b6791d83efe5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/52fac423-d66b-4799-b95c-b6791d83efe5/pipeline.log\">pipeline</a>"]},{"id":"d52f4593-df37-4ff0-9cbd-e3a5cb9ee292","name":"Fedora - 18-minimal","status":"complete","outcome":"passed","runTime":707.132865,"created":"2025-01-21T08:28:33.363579","updated":"2025-01-21T08:28:33.363587","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d52f4593-df37-4ff0-9cbd-e3a5cb9ee292\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d52f4593-df37-4ff0-9cbd-e3a5cb9ee292/pipeline.log\">pipeline</a>"]},{"id":"6ea4fac7-81f2-47ac-a83c-b2bc5ecf445f","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":691.649619,"created":"2025-01-21T08:29:05.085259","updated":"2025-01-21T08:29:05.085267","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6ea4fac7-81f2-47ac-a83c-b2bc5ecf445f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6ea4fac7-81f2-47ac-a83c-b2bc5ecf445f/pipeline.log\">pipeline</a>"]},{"id":"af9292b4-987d-40f7-9320-466dd6ef123f","name":"Fedora - 20","status":"complete","outcome":"error","runTime":807.841098,"created":"2025-01-21T08:28:36.979345","updated":"2025-01-21T08:28:36.979351","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/af9292b4-987d-40f7-9320-466dd6ef123f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/af9292b4-987d-40f7-9320-466dd6ef123f/pipeline.log\">pipeline</a>"]},{"id":"17d155d3-b711-4d6f-8425-97f32d72b05a","name":"Fedora - 18","status":"complete","outcome":"passed","runTime":813.758567,"created":"2025-01-21T08:28:33.467021","updated":"2025-01-21T08:28:33.467029","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/17d155d3-b711-4d6f-8425-97f32d72b05a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/17d155d3-b711-4d6f-8425-97f32d72b05a/pipeline.log\">pipeline</a>"]},{"id":"7f5c376b-a423-4877-81f6-fe0c8b99b959","name":"Fedora - 22","status":"complete","outcome":"error","runTime":839.714966,"created":"2025-01-21T08:28:46.214032","updated":"2025-01-21T08:28:46.214040","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7f5c376b-a423-4877-81f6-fe0c8b99b959\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7f5c376b-a423-4877-81f6-fe0c8b99b959/pipeline.log\">pipeline</a>"]},{"id":"0eb775c2-fb6f-4589-bc67-591ad6337e7c","name":"RHEL9 - 18-minimal","status":"complete","outcome":"passed","runTime":1028.989308,"created":"2025-01-21T08:28:36.950198","updated":"2025-01-21T08:28:36.950205","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0eb775c2-fb6f-4589-bc67-591ad6337e7c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0eb775c2-fb6f-4589-bc67-591ad6337e7c/pipeline.log\">pipeline</a>"]},{"id":"f9f9cd48-ab5e-40aa-ad28-b3ff49422550","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1003.655816,"created":"2025-01-21T08:28:42.210636","updated":"2025-01-21T08:28:42.210644","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f9f9cd48-ab5e-40aa-ad28-b3ff49422550\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f9f9cd48-ab5e-40aa-ad28-b3ff49422550/pipeline.log\">pipeline</a>"]},{"id":"a2c7ca31-5830-4eaa-aa25-6c8fb9d2bdbf","name":"RHEL9 - 18","status":"complete","outcome":"passed","runTime":1045.603122,"created":"2025-01-21T08:28:33.575242","updated":"2025-01-21T08:28:33.575250","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2c7ca31-5830-4eaa-aa25-6c8fb9d2bdbf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2c7ca31-5830-4eaa-aa25-6c8fb9d2bdbf/pipeline.log\">pipeline</a>"]},{"id":"d1eeceb4-fe33-4823-bfb3-dd296c9af919","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":1095.995891,"created":"2025-01-21T08:28:34.182555","updated":"2025-01-21T08:28:34.182564","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1eeceb4-fe33-4823-bfb3-dd296c9af919\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1eeceb4-fe33-4823-bfb3-dd296c9af919/pipeline.log\">pipeline</a>"]},{"id":"802438c0-484c-4ef1-a2b7-d4b574f298a1","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1158.311216,"created":"2025-01-21T08:28:33.493580","updated":"2025-01-21T08:28:33.493589","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/802438c0-484c-4ef1-a2b7-d4b574f298a1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/802438c0-484c-4ef1-a2b7-d4b574f298a1/pipeline.log\">pipeline</a>"]},{"id":"e13b12bf-b271-4cc4-af9b-0be9a3442e37","name":"RHEL8 - 18","status":"complete","outcome":"passed","runTime":1218.276002,"created":"2025-01-21T08:28:33.929282","updated":"2025-01-21T08:28:33.929292","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e13b12bf-b271-4cc4-af9b-0be9a3442e37\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e13b12bf-b271-4cc4-af9b-0be9a3442e37/pipeline.log\">pipeline</a>"]},{"id":"5de887d4-b708-48d9-b3eb-779d4afd0264","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1242.144569,"created":"2025-01-21T08:28:48.942009","updated":"2025-01-21T08:28:48.942018","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5de887d4-b708-48d9-b3eb-779d4afd0264\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5de887d4-b708-48d9-b3eb-779d4afd0264/pipeline.log\">pipeline</a>"]},{"id":"4ffda9f5-a06f-4c66-b8a5-156676bc6c79","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":1240.781325,"created":"2025-01-21T08:28:39.773666","updated":"2025-01-21T08:28:39.773671","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ffda9f5-a06f-4c66-b8a5-156676bc6c79\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ffda9f5-a06f-4c66-b8a5-156676bc6c79/pipeline.log\">pipeline</a>"]},{"id":"a96720d7-1a95-4706-9963-d9ce9f349cd2","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1384.136516,"created":"2025-01-21T08:28:36.586560","updated":"2025-01-21T08:28:36.586568","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a96720d7-1a95-4706-9963-d9ce9f349cd2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a96720d7-1a95-4706-9963-d9ce9f349cd2/pipeline.log\">pipeline</a>"]},{"id":"33e00975-2ee1-42f9-8636-835a8105a215","name":"RHEL9 - 22-minimal","runTime":993.655552,"created":"2025-01-21T08:36:49.770361","updated":"2025-01-21T08:36:49.770374","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/33e00975-2ee1-42f9-8636-835a8105a215\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/33e00975-2ee1-42f9-8636-835a8105a215/pipeline.log\">pipeline</a>"]}]} -->