### PR TITLE
Use python 3.12 in the nodejs 22 container for native extensions.

### DIFF
--- a/22/Dockerfile.rhel8
+++ b/22/Dockerfile.rhel8
@@ -54,7 +54,8 @@ LABEL summary="$SUMMARY" \
       usage="s2i build <SOURCE-REPOSITORY> ubi8/$NAME-$NODEJS_VERSION:latest <APP-NAME>"
 
 RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel python3.12" && \
+    MODULE_DEPS="make gcc-toolset-14-gcc gcc-toolset-14-gcc-c++ gcc-toolset-14-runtime \
+        libatomic_ops git openssl-devel python3.12" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper-libs which" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
@@ -74,6 +75,11 @@ RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
     rpm-file-permissions
 
 USER 1001
+
+# Enable the SCL for all bash scripts.
+ENV BASH_ENV=/opt/rh/gcc-toolset-14/enable \
+    ENV=/opt/rh/gcc-toolset-14/enable \
+    PROMPT_COMMAND=". /opt/rh/gcc-toolset-14/enable"
 
 # Set the default CMD to print the usage of the language image
 CMD $STI_SCRIPTS_PATH/usage

--- a/22/Dockerfile.rhel8
+++ b/22/Dockerfile.rhel8
@@ -54,10 +54,9 @@ LABEL summary="$SUMMARY" \
       usage="s2i build <SOURCE-REPOSITORY> ubi8/$NAME-$NODEJS_VERSION:latest <APP-NAME>"
 
 RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
+    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel python3.12" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper-libs which" && \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
-    ln -s /usr/libexec/platform-python /usr/bin/python3 && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \


### PR DESCRIPTION
A nodejs tool "node-gyp" used for compiling native extensions from npm from source requires python version >= 3.8.

Install the high-enough python version 3.12 for RHEL 8 container. RHEL 8 base version is 3.6, it is not enough for node-gyp. Python 3.12 in RHEL 8 has support until 2029,
the currently projected RHEL 8 EOL, similarly to python 3.6

nodejs-22-minimal container does not do anything with python, leave that Containerfile as-is.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- issue-commentator = {"comment-id":"2648470306"} -->

























































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2651024937","data":[{"id":"4718a334-8d7b-4096-bf34-6413540399b1","name":"Fedora - 18-minimal","status":"complete","outcome":"passed","runTime":475.063385,"created":"2025-02-11T14:34:14.930704","updated":"2025-02-11T14:34:14.930714","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4718a334-8d7b-4096-bf34-6413540399b1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4718a334-8d7b-4096-bf34-6413540399b1/pipeline.log\">pipeline</a>"]},{"id":"26feca0a-331c-45e6-851a-d8ec24a50980","name":"Fedora - 18","status":"complete","outcome":"passed","runTime":658.962923,"created":"2025-02-26T12:29:44.288736","updated":"2025-02-26T12:29:44.288743","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/26feca0a-331c-45e6-851a-d8ec24a50980\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/26feca0a-331c-45e6-851a-d8ec24a50980/pipeline.log\">pipeline</a>"]},{"id":"3c2222ac-3e2e-4627-be28-6e18437caba5","name":"CentOS Stream 9 - 20","status":"complete","outcome":"error","runTime":860.782711,"created":"2025-02-26T12:29:48.610718","updated":"2025-02-26T12:29:48.610726","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3c2222ac-3e2e-4627-be28-6e18437caba5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3c2222ac-3e2e-4627-be28-6e18437caba5/pipeline.log\">pipeline</a>"]},{"id":"889dd20e-5fb4-4794-a7fa-859a397420ee","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":782.196598,"created":"2025-02-26T12:29:48.315221","updated":"2025-02-26T12:29:48.315229","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/889dd20e-5fb4-4794-a7fa-859a397420ee\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/889dd20e-5fb4-4794-a7fa-859a397420ee/pipeline.log\">pipeline</a>"]},{"id":"fe76dde2-3b5e-40ab-b76b-c98d1bc12413","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":693.246973,"created":"2025-02-26T12:29:50.928451","updated":"2025-02-26T12:29:50.928459","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fe76dde2-3b5e-40ab-b76b-c98d1bc12413\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fe76dde2-3b5e-40ab-b76b-c98d1bc12413/pipeline.log\">pipeline</a>"]},{"id":"170bdf1f-54fe-4de0-b9f9-60f3512209c8","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":550.269628,"created":"2025-02-26T12:29:55.651659","updated":"2025-02-26T12:29:55.651666","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/170bdf1f-54fe-4de0-b9f9-60f3512209c8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/170bdf1f-54fe-4de0-b9f9-60f3512209c8/pipeline.log\">pipeline</a>"]},{"id":"230cc4fe-2e30-4cae-bff5-8a4360d8cf1a","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":529.25891,"created":"2025-02-26T12:30:02.419580","updated":"2025-02-26T12:30:02.419588","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/230cc4fe-2e30-4cae-bff5-8a4360d8cf1a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/230cc4fe-2e30-4cae-bff5-8a4360d8cf1a/pipeline.log\">pipeline</a>"]},{"id":"f2d55184-10ad-4c52-a8b3-f49c4bcb80d4","name":"RHEL9 - 18","status":"complete","outcome":"passed","runTime":1179.935549,"created":"2025-02-26T12:29:44.921323","updated":"2025-02-26T12:29:44.921335","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2d55184-10ad-4c52-a8b3-f49c4bcb80d4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2d55184-10ad-4c52-a8b3-f49c4bcb80d4/pipeline.log\">pipeline</a>"]},{"id":"55dce25b-5f60-4e48-9e8c-c4fe8a7765b8","name":"RHEL9 - 18-minimal","status":"complete","outcome":"passed","runTime":1072.173322,"created":"2025-02-26T12:29:48.180606","updated":"2025-02-26T12:29:48.180612","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/55dce25b-5f60-4e48-9e8c-c4fe8a7765b8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/55dce25b-5f60-4e48-9e8c-c4fe8a7765b8/pipeline.log\">pipeline</a>"]},{"id":"8722124a-1c5d-4dc6-b721-76f747b37e15","name":"RHEL8 - 18","status":"complete","outcome":"passed","runTime":1330.510905,"created":"2025-02-26T12:29:44.003955","updated":"2025-02-26T12:29:44.003961","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8722124a-1c5d-4dc6-b721-76f747b37e15\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8722124a-1c5d-4dc6-b721-76f747b37e15/pipeline.log\">pipeline</a>"]},{"id":"989c805b-a347-4e51-b761-3f8d07282ca0","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":818.88411,"created":"2025-02-26T12:30:08.634916","updated":"2025-02-26T12:30:08.634922","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/989c805b-a347-4e51-b761-3f8d07282ca0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/989c805b-a347-4e51-b761-3f8d07282ca0/pipeline.log\">pipeline</a>"]},{"id":"af713cfc-8c5c-4a53-a212-de7710bb6e62","name":"RHEL8 - 18-minimal","status":"complete","outcome":"passed","runTime":1300.951675,"created":"2025-02-26T12:29:47.426753","updated":"2025-02-26T12:29:47.426761","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/af713cfc-8c5c-4a53-a212-de7710bb6e62\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/af713cfc-8c5c-4a53-a212-de7710bb6e62/pipeline.log\">pipeline</a>"]},{"id":"0469d618-fa05-468b-8f3e-7eda019b1248","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":487.642319,"created":"2025-02-26T12:37:58.397411","updated":"2025-02-26T12:37:58.397417","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0469d618-fa05-468b-8f3e-7eda019b1248\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0469d618-fa05-468b-8f3e-7eda019b1248/pipeline.log\">pipeline</a>"]},{"id":"f9081b44-dbbe-4974-b821-24a58cbe45a6","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":603.731164,"created":"2025-02-26T12:39:51.446595","updated":"2025-02-26T12:39:51.446601","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f9081b44-dbbe-4974-b821-24a58cbe45a6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f9081b44-dbbe-4974-b821-24a58cbe45a6/pipeline.log\">pipeline</a>"]},{"id":"b098ef57-9e00-49a2-8ba4-5566998852fc","name":"RHEL8 - 20","status":"complete","outcome":"error","runTime":1453.722266,"created":"2025-02-26T12:29:50.054835","updated":"2025-02-26T12:29:50.054840","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b098ef57-9e00-49a2-8ba4-5566998852fc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b098ef57-9e00-49a2-8ba4-5566998852fc/pipeline.log\">pipeline</a>"]},{"id":"ae2e5f33-df8c-429d-8708-5d11323d1b61","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1368.496743,"created":"2025-02-26T12:29:50.919299","updated":"2025-02-26T12:29:50.919306","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ae2e5f33-df8c-429d-8708-5d11323d1b61\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ae2e5f33-df8c-429d-8708-5d11323d1b61/pipeline.log\">pipeline</a>"]},{"id":"307d4ea1-fd0f-4fa0-8762-e1412751a5c9","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":1266.582757,"created":"2025-02-26T12:30:00.447287","updated":"2025-02-26T12:30:00.447293","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/307d4ea1-fd0f-4fa0-8762-e1412751a5c9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/307d4ea1-fd0f-4fa0-8762-e1412751a5c9/pipeline.log\">pipeline</a>"]},{"id":"e1db79fc-0f94-48fc-bf73-941d2ef80974","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1030.526266,"created":"2025-02-26T12:29:59.023536","updated":"2025-02-26T12:29:59.023544","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e1db79fc-0f94-48fc-bf73-941d2ef80974\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e1db79fc-0f94-48fc-bf73-941d2ef80974/pipeline.log\">pipeline</a>"]},{"id":"b11947fa-fe47-4ad4-96e4-7c1f63ba930e","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":930.004261,"created":"2025-02-26T12:40:04.861721","updated":"2025-02-26T12:40:04.861727","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b11947fa-fe47-4ad4-96e4-7c1f63ba930e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b11947fa-fe47-4ad4-96e4-7c1f63ba930e/pipeline.log\">pipeline</a>"]},{"id":"7a8bfd96-f606-407b-a65c-b5c983a3f4bf","name":"RHEL10 - 22-minimal","status":"complete","outcome":"passed","runTime":906.157181,"created":"2025-02-26T12:40:06.987683","updated":"2025-02-26T12:40:06.987689","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a8bfd96-f606-407b-a65c-b5c983a3f4bf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7a8bfd96-f606-407b-a65c-b5c983a3f4bf/pipeline.log\">pipeline</a>"]},{"id":"3df9a949-e966-4878-a52d-647f023592da","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":1387.939761,"created":"2025-02-26T12:30:11.713699","updated":"2025-02-26T12:30:11.713705","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3df9a949-e966-4878-a52d-647f023592da\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3df9a949-e966-4878-a52d-647f023592da/pipeline.log\">pipeline</a>"]},{"id":"520480db-4bab-4a4f-84be-bd71e7966559","name":"RHEL8 - 22-minimal","runTime":1297.623947,"created":"2025-02-26T12:41:49.112691","updated":"2025-02-26T12:41:49.112724","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/520480db-4bab-4a4f-84be-bd71e7966559\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/520480db-4bab-4a4f-84be-bd71e7966559/pipeline.log\">pipeline</a>"]},{"id":"d32a5643-9f5c-458e-ad14-4988855944dd","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1342.6803,"created":"2025-02-26T12:30:24.195863","updated":"2025-02-26T12:30:24.195872","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d32a5643-9f5c-458e-ad14-4988855944dd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d32a5643-9f5c-458e-ad14-4988855944dd/pipeline.log\">pipeline</a>"]},{"id":"0c011f8b-b9cb-40ee-ac56-be82eefa8aa3","name":"RHEL8 - 22","status":"complete","outcome":"passed","runTime":1699.569517,"created":"2025-02-26T12:30:41.015445","updated":"2025-02-26T12:30:41.015452","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c011f8b-b9cb-40ee-ac56-be82eefa8aa3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c011f8b-b9cb-40ee-ac56-be82eefa8aa3/pipeline.log\">pipeline</a>"]}]} -->