### PR TITLE
Separate handling of non-default nodejs to sync Fedora 41 Dockerfiles

### DIFF
--- a/18-minimal/Dockerfile.fedora
+++ b/18-minimal/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-minimal:38
+FROM quay.io/fedora/fedora-minimal:41
 
 EXPOSE 8080
 
@@ -15,9 +15,11 @@ EXPOSE 8080
 ENV APP_ROOT=/opt/app-root \
     # The $HOME is not set by default, but some applications need this variable
     HOME=/opt/app-root/src \
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
     NPM_RUN=start \
     PLATFORM="fedora" \
     NODEJS_VERSION=18 \
+    DEFAULT_NODEJS_VERSION=22 \
     NPM_RUN=start \
     NAME=nodejs
 
@@ -49,14 +51,17 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n nodejs-npm findutils tar which nss_wrapper-libs" && \
+RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     microdnf clean all && \
-    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 
-COPY ./s2i/bin/ /usr/libexec/s2i
-RUN chmod +x /usr/libexec/s2i/init-wrapper
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+RUN chmod +x $STI_SCRIPTS_PATH/init-wrapper $STI_SCRIPTS_PATH/ensure-default-node
+
+# Make sure a user has non-versioned binaries available for the correct Node.js version
+RUN $STI_SCRIPTS_PATH/ensure-default-node
 
 # Copy extra files to the image.
 COPY ./root/ /

--- a/18-minimal/s2i/bin/ensure-default-node
+++ b/18-minimal/s2i/bin/ensure-default-node
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xe
+
+for bin in node npm npx ; do
+  [ -f /usr/bin/$bin ] || ln -s /usr/bin/$bin-$NODEJS_VERSION /usr/bin/$bin
+done
+
+if [ $NODEJS_VERSION -ne $DEFAULT_NODEJS_VERSION ] ; then
+  ln -s /usr/lib/node_modules_$DEFAULT_NODEJS_VERSION/nodemon /usr/lib/node_modules_$NODEJS_VERSION/nodemon
+fi
+
+[ -d /usr/lib/node_modules_$NODEJS_VERSION/nodemon ] && echo "Found nodemon for version $NODEJS_VERSION"
+
+node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION"

--- a/18/Dockerfile.fedora
+++ b/18/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/s2i-core:38
+FROM quay.io/fedora/s2i-core:41
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
@@ -17,6 +17,7 @@ EXPOSE 8080
 # * 8080 - Unprivileged port used by nodejs application
 
 ENV NODEJS_VERSION=18 \
+    DEFAULT_NODEJS_VERSION=22 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
@@ -48,16 +49,16 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="oc new-app $FGC/$NAME~<SOURCE-REPOSITORY>"
 
-RUN MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
-    INSTALL_PKGS="$MODULE_DEPS nodejs nodejs-nodemon nodejs-npm nss_wrapper-libs which" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-    yum -y clean all --enablerepo='*'
+RUN INSTALL_PKGS="make gcc gcc-c++ libatomic_ops git openssl-devel nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    dnf -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
-RUN chmod +x $STI_SCRIPTS_PATH/init-wrapper
+RUN chmod +x $STI_SCRIPTS_PATH/init-wrapper $STI_SCRIPTS_PATH/ensure-default-node
+
+# Make sure a user has non-versioned binaries available for the correct Node.js version
+RUN $STI_SCRIPTS_PATH/ensure-default-node
 
 # Copy extra files to the image, including help file.
 COPY ./root/ /

--- a/18/s2i/bin/ensure-default-node
+++ b/18/s2i/bin/ensure-default-node
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xe
+
+for bin in node npm npx ; do
+  [ -f /usr/bin/$bin ] || ln -s /usr/bin/$bin-$NODEJS_VERSION /usr/bin/$bin
+done
+
+if [ $NODEJS_VERSION -ne $DEFAULT_NODEJS_VERSION ] ; then
+  ln -s /usr/lib/node_modules_$DEFAULT_NODEJS_VERSION/nodemon /usr/lib/node_modules_$NODEJS_VERSION/nodemon
+fi
+
+[ -d /usr/lib/node_modules_$NODEJS_VERSION/nodemon ] && echo "Found nodemon for version $NODEJS_VERSION"
+
+node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION"

--- a/20-minimal/Dockerfile.fedora
+++ b/20-minimal/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-minimal:38
+FROM quay.io/fedora/fedora-minimal:41
 
 EXPOSE 8080
 
@@ -15,9 +15,11 @@ EXPOSE 8080
 ENV APP_ROOT=/opt/app-root \
     # The $HOME is not set by default, but some applications need this variable
     HOME=/opt/app-root/src \
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
     NPM_RUN=start \
     PLATFORM="fedora" \
     NODEJS_VERSION=20 \
+    DEFAULT_NODEJS_VERSION=22 \
     NPM_RUN=start \
     NAME=nodejs
 
@@ -52,16 +54,14 @@ LABEL summary="$SUMMARY" \
 RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     microdnf clean all && \
-    ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
-    ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
-    ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-    ln -s /usr/lib/node_modules_18/nodemon /usr/lib/node_modules_$NODEJS_VERSION/nodemon && \
-    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 
-#
-COPY ./s2i/bin/ /usr/libexec/s2i
-RUN chmod +x /usr/libexec/s2i/init-wrapper
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+RUN chmod +x $STI_SCRIPTS_PATH/init-wrapper $STI_SCRIPTS_PATH/ensure-default-node
+
+# Make sure a user has non-versioned binaries available for the correct Node.js version
+RUN $STI_SCRIPTS_PATH/ensure-default-node
 
 # Copy extra files to the image.
 COPY ./root/ /

--- a/20-minimal/s2i/bin/ensure-default-node
+++ b/20-minimal/s2i/bin/ensure-default-node
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xe
+
+for bin in node npm npx ; do
+  [ -f /usr/bin/$bin ] || ln -s /usr/bin/$bin-$NODEJS_VERSION /usr/bin/$bin
+done
+
+if [ $NODEJS_VERSION -ne $DEFAULT_NODEJS_VERSION ] ; then
+  ln -s /usr/lib/node_modules_$DEFAULT_NODEJS_VERSION/nodemon /usr/lib/node_modules_$NODEJS_VERSION/nodemon
+fi
+
+[ -d /usr/lib/node_modules_$NODEJS_VERSION/nodemon ] && echo "Found nodemon for version $NODEJS_VERSION"
+
+node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION"

--- a/20/Dockerfile.fedora
+++ b/20/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/s2i-core:38
+FROM quay.io/fedora/s2i-core:41
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
@@ -17,6 +17,7 @@ EXPOSE 8080
 # * 8080 - Unprivileged port used by nodejs application
 
 ENV NODEJS_VERSION=20 \
+    DEFAULT_NODEJS_VERSION=22 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
@@ -48,20 +49,16 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="oc new-app $FGC/$NAME~<SOURCE-REPOSITORY>"
 
-RUN MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
-    INSTALL_PKGS="$MODULE_DEPS nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
-    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
-    ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
-    ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-    ln -s /usr/lib/node_modules_18/nodemon /usr/lib/node_modules_$NODEJS_VERSION/nodemon && \
-    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-    yum -y clean all --enablerepo='*'
+RUN INSTALL_PKGS="make gcc gcc-c++ libatomic_ops git openssl-devel nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
+    dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    dnf -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
-RUN chmod +x $STI_SCRIPTS_PATH/init-wrapper
+RUN chmod +x $STI_SCRIPTS_PATH/init-wrapper $STI_SCRIPTS_PATH/ensure-default-node
+
+# Make sure a user has non-versioned binaries available for the correct Node.js version
+RUN $STI_SCRIPTS_PATH/ensure-default-node
 
 # Copy extra files to the image, including help file.
 COPY ./root/ /

--- a/20/s2i/bin/ensure-default-node
+++ b/20/s2i/bin/ensure-default-node
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xe
+
+for bin in node npm npx ; do
+  [ -f /usr/bin/$bin ] || ln -s /usr/bin/$bin-$NODEJS_VERSION /usr/bin/$bin
+done
+
+if [ $NODEJS_VERSION -ne $DEFAULT_NODEJS_VERSION ] ; then
+  ln -s /usr/lib/node_modules_$DEFAULT_NODEJS_VERSION/nodemon /usr/lib/node_modules_$NODEJS_VERSION/nodemon
+fi
+
+[ -d /usr/lib/node_modules_$NODEJS_VERSION/nodemon ] && echo "Found nodemon for version $NODEJS_VERSION"
+
+node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION"

--- a/22-minimal/Dockerfile.fedora
+++ b/22-minimal/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-minimal:40
+FROM quay.io/fedora/fedora-minimal:41
 
 EXPOSE 8080
 
@@ -15,9 +15,11 @@ EXPOSE 8080
 ENV APP_ROOT=/opt/app-root \
     # The $HOME is not set by default, but some applications need this variable
     HOME=/opt/app-root/src \
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
     NPM_RUN=start \
     PLATFORM="fedora" \
     NODEJS_VERSION=22 \
+    DEFAULT_NODEJS_VERSION=22 \
     NPM_RUN=start \
     NAME=nodejs
 
@@ -52,15 +54,14 @@ LABEL summary="$SUMMARY" \
 RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     microdnf clean all && \
-    ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
-    ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
-    ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 
-#
-COPY ./s2i/bin/ /usr/libexec/s2i
-RUN chmod +x /usr/libexec/s2i/init-wrapper
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+RUN chmod +x $STI_SCRIPTS_PATH/init-wrapper $STI_SCRIPTS_PATH/ensure-default-node
+
+# Make sure a user has non-versioned binaries available for the correct Node.js version
+RUN $STI_SCRIPTS_PATH/ensure-default-node
 
 # Copy extra files to the image.
 COPY ./root/ /

--- a/22-minimal/s2i/bin/ensure-default-node
+++ b/22-minimal/s2i/bin/ensure-default-node
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xe
+
+for bin in node npm npx ; do
+  [ -f /usr/bin/$bin ] || ln -s /usr/bin/$bin-$NODEJS_VERSION /usr/bin/$bin
+done
+
+if [ $NODEJS_VERSION -ne $DEFAULT_NODEJS_VERSION ] ; then
+  ln -s /usr/lib/node_modules_$DEFAULT_NODEJS_VERSION/nodemon /usr/lib/node_modules_$NODEJS_VERSION/nodemon
+fi
+
+[ -d /usr/lib/node_modules_$NODEJS_VERSION/nodemon ] && echo "Found nodemon for version $NODEJS_VERSION"
+
+node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION"

--- a/22/Dockerfile.fedora
+++ b/22/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/s2i-core:40
+FROM quay.io/fedora/s2i-core:41
 
 # This image provides a Node.JS environment you can use to run your Node.JS
 # applications.
@@ -17,6 +17,7 @@ EXPOSE 8080
 # * 8080 - Unprivileged port used by nodejs application
 
 ENV NODEJS_VERSION=22 \
+    DEFAULT_NODEJS_VERSION=22 \
     NPM_RUN=start \
     NAME=nodejs \
     NPM_CONFIG_PREFIX=$HOME/.npm-global \
@@ -50,16 +51,14 @@ LABEL summary="$SUMMARY" \
 
 RUN INSTALL_PKGS="make gcc gcc-c++ libatomic_ops git openssl-devel nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
-    ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
-    ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
-    ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     dnf -y clean all --enablerepo='*'
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH
-RUN chmod +x /usr/libexec/s2i/init-wrapper
+RUN chmod +x $STI_SCRIPTS_PATH/init-wrapper $STI_SCRIPTS_PATH/ensure-default-node
+
+# Make sure a user has non-versioned binaries available for the correct Node.js version
+RUN $STI_SCRIPTS_PATH/ensure-default-node
 
 # Copy extra files to the image, including help file.
 COPY ./root/ /

--- a/22/s2i/bin/ensure-default-node
+++ b/22/s2i/bin/ensure-default-node
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -xe
+
+for bin in node npm npx ; do
+  [ -f /usr/bin/$bin ] || ln -s /usr/bin/$bin-$NODEJS_VERSION /usr/bin/$bin
+done
+
+if [ $NODEJS_VERSION -ne $DEFAULT_NODEJS_VERSION ] ; then
+  ln -s /usr/lib/node_modules_$DEFAULT_NODEJS_VERSION/nodemon /usr/lib/node_modules_$NODEJS_VERSION/nodemon
+fi
+
+[ -d /usr/lib/node_modules_$NODEJS_VERSION/nodemon ] && echo "Found nodemon for version $NODEJS_VERSION"
+
+node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION"


### PR DESCRIPTION
This PR requires the changes in the nodejs18 RPMs to get to the stable repo first, they're in bodhi now: https://bodhi.fedoraproject.org/updates/FEDORA-2025-e21c7819e3

The update ^^ fixes a problem that nodejs18 pulled in nodejs package as a dependency.

With that, we can use F41 as a base for all Node.js versions.

Since this sync to the newest Fedora required to rework the mechanism of "making the alternative Node.js to be the only one in the container and without version in CLI names", aka adding symlinks and testing that we actually have a correct version available, I've separated these steps into a separate script, rather than making the Dockerfile.fedora more complex. This did not seem to be required in RHEL/CXS versions, but once we put new alternative versions to RHEL 10, we might reuse this script there as well (i.e. create RHEL10/C10S dockerfile from the Fedora Dockerfile).

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
