### PR TITLE
New GitHub action for testing nodejs container by test-upstream keyword.

### DIFF
--- a/.github/workflows/container-upstream-tests.yml
+++ b/.github/workflows/container-upstream-tests.yml
@@ -5,21 +5,21 @@ on:
 jobs:
   container-tests:
     # This job only runs for '[test]' pull request comments by owner, member
-    name: "Container tests: ${{ matrix.version }} - ${{ matrix.os_test }}"
+    name: "Container Upstream Tests ${{ matrix.version }} - ${{ matrix.os_test }}"
     runs-on: ubuntu-20.04
     concurrency:
-      group: container-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
+      group: container-upstream-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
       matrix:
         version: [ "18", "18-minimal", "20", "20-minimal", "22", "22-minimal" ]
         os_test: [ "fedora", "rhel8", "rhel9", "rhel10", "c9s", "c10s" ]
-        test_case: [ "container" ]
+        test_case: [ "container-upstream" ]
 
     if: |
       github.event.issue.pull_request
-      && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))
+      && (contains(github.event.comment.body, '[test-upstream]') || contains(github.event.comment.body, '[test-all]'))
       && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
     steps:
       - uses: sclorg/tfaga-wrapper@main


### PR DESCRIPTION
This commit separates container tests from container upstream tests

so we are able to test both of them and see results in Pull Request window directly.

See PR https://github.com/sclorg/tfaga-wrapper/pull/38

<!-- issue-commentator = {"comment-id":"2757758544"} -->