### PR TITLE
Switch GitHub Action to use ubuntu-latest

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository_owner == 'sclorg'
     strategy:
       fail-fast: false

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -6,7 +6,7 @@ jobs:
   container-tests:
     # This job only runs for '[test]' pull request comments by owner, member
     name: "Container tests: ${{ matrix.version }} - ${{ matrix.os_test }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: container-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
       cancel-in-progress: true

--- a/.github/workflows/container-upstream-tests.yml
+++ b/.github/workflows/container-upstream-tests.yml
@@ -4,9 +4,9 @@ on:
       - created
 jobs:
   container-tests:
-    # This job only runs for '[test]' pull request comments by owner, member
+    # This job only runs for '[test-upstream]' pull request comments by owner, member
     name: "Container Upstream Tests ${{ matrix.version }} - ${{ matrix.os_test }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: container-upstream-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
       cancel-in-progress: true


### PR DESCRIPTION
Switch GitHub Action to use ubuntu-latest

Switch GitHub Action to use ubuntu-latest.

The version 20.04 was deprecated and it is
not possible to run it at all

<!-- issue-commentator = {"comment-id":"2820488258"} -->