### PR TITLE
Fix OpenShift tests and enable testing on shared_cluster

### DIFF
--- a/test/test_nodejs_ex_standalone.py
+++ b/test/test_nodejs_ex_standalone.py
@@ -31,7 +31,7 @@ class TestNodeJSExTemplate:
             context=".",
             service_name=service_name
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Node.js Crud Application"
         )

--- a/test/test_nodejs_ex_templates.py
+++ b/test/test_nodejs_ex_templates.py
@@ -43,6 +43,8 @@ class TestDeployNodeJSExTemplate:
     )
     def test_nodejs_ex_template_inside_cluster(self, template):
         service_name = "nodejs-testing"
+        if os == "rhel10":
+            pytest.skip("Do NOT test on RHEL10 yet.")
         template_url = self.oc_api.get_raw_url_for_json(
             container="nodejs-ex", dir="openshift/templates", filename=template, branch="master"
         )
@@ -73,7 +75,7 @@ class TestDeployNodeJSExTemplate:
             openshift_args=openshift_args
 
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="Node.js Crud Application"
         )

--- a/test/test_nodejs_s2i_standalone.py
+++ b/test/test_nodejs_s2i_standalone.py
@@ -31,7 +31,7 @@ class TestNodeJSExTemplate:
             context="test/test-app",
             service_name=service_name
         )
-        assert self.oc_api.template_deployed(name_in_template=service_name)
+        assert self.oc_api.is_template_deployed(name_in_template=service_name)
         assert self.oc_api.check_response_inside_cluster(
             name_in_template=service_name, expected_output="This is a node.js echo service"
         )

--- a/test/test_shared_helm_nodejs_application.py
+++ b/test/test_shared_helm_nodejs_application.py
@@ -38,31 +38,11 @@ class TestHelmNodeJSApplication:
     def teardown_method(self):
         self.hc_api.delete_project()
 
-    def test_curl_connection(self):
-        if self.hc_api.oc_api.shared_cluster:
-            pytest.skip("Do NOT test on shared cluster")
-        self.hc_api.package_name = "nodejs-imagestreams"
-        self.hc_api.helm_package()
-        assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "nodejs-application"
-        assert self.hc_api.helm_package()
-        assert self.hc_api.helm_installation(
-            values={
-                "nodejs_version": f"{VERSION}{TAG}",
-                "namespace": self.hc_api.namespace
-            }
-        )
-        assert self.hc_api.is_s2i_pod_running(pod_name_prefix="nodejs-example")
-        assert self.hc_api.test_helm_curl_output(
-            route_name="nodejs-example",
-            expected_str="Node.js Crud Application"
-        )
-
     def test_by_helm_test(self):
-        self.hc_api.package_name = "nodejs-imagestreams"
+        self.hc_api.package_name = "redhat-nodejs-imagestreams"
         self.hc_api.helm_package()
         assert self.hc_api.helm_installation()
-        self.hc_api.package_name = "nodejs-application"
+        self.hc_api.package_name = "redhat-nodejs-application"
         assert self.hc_api.helm_package()
         assert self.hc_api.helm_installation(
             values={


### PR DESCRIPTION
This pull request enables testing NodeJS on Shared_cluster.

Also add prefix to helm charts.

<!-- issue-commentator = {"comment-id":"2846849878"} -->

<!-- testing-farm = {"lock":"false","comment-id":"2846873366","data":[{"id":"e8a5c2b7-2e77-4e77-a154-e9cfbc044aa3","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":798.97773,"created":"2025-05-02T10:06:43.707439","updated":"2025-05-02T10:06:43.707445","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8a5c2b7-2e77-4e77-a154-e9cfbc044aa3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8a5c2b7-2e77-4e77-a154-e9cfbc044aa3/pipeline.log\">pipeline</a>"]},{"id":"2709df2e-4651-44fe-9470-4d9ea0a61af9","name":"RHEL8 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":806.760903,"created":"2025-05-02T10:06:50.043235","updated":"2025-05-02T10:06:50.043241","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2709df2e-4651-44fe-9470-4d9ea0a61af9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2709df2e-4651-44fe-9470-4d9ea0a61af9/pipeline.log\">pipeline</a>"]},{"id":"07848cfa-a36b-4803-ba07-f9e9df778a68","name":"RHEL10 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":833.538012,"created":"2025-05-02T10:06:41.011518","updated":"2025-05-02T10:06:41.011524","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/07848cfa-a36b-4803-ba07-f9e9df778a68\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/07848cfa-a36b-4803-ba07-f9e9df778a68/pipeline.log\">pipeline</a>"]},{"id":"951d65aa-317c-49ad-87df-7b17027b919b","name":"RHEL9 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":859.811006,"created":"2025-05-02T10:06:42.103521","updated":"2025-05-02T10:06:42.103532","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/951d65aa-317c-49ad-87df-7b17027b919b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/951d65aa-317c-49ad-87df-7b17027b919b/pipeline.log\">pipeline</a>"]},{"id":"1d08ee9d-c2b8-4197-b810-ff71fe84b54f","name":"RHEL9 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":893.309184,"created":"2025-05-02T10:06:41.542290","updated":"2025-05-02T10:06:41.542296","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d08ee9d-c2b8-4197-b810-ff71fe84b54f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1d08ee9d-c2b8-4197-b810-ff71fe84b54f/pipeline.log\">pipeline</a>"]},{"id":"4430bcab-5e5c-4225-a168-b8d8cddc0a66","name":"RHEL9 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":934.690398,"created":"2025-05-02T10:06:42.069961","updated":"2025-05-02T10:06:42.069966","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4430bcab-5e5c-4225-a168-b8d8cddc0a66\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4430bcab-5e5c-4225-a168-b8d8cddc0a66/pipeline.log\">pipeline</a>"]},{"id":"fc39d3c3-f2ca-4a94-9442-6e7d43c66e7d","name":"RHEL8 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":943.000263,"created":"2025-05-02T10:06:40.494175","updated":"2025-05-02T10:06:40.494182","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc39d3c3-f2ca-4a94-9442-6e7d43c66e7d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc39d3c3-f2ca-4a94-9442-6e7d43c66e7d/pipeline.log\">pipeline</a>"]},{"id":"8cad2c71-4a21-4bc5-9828-c3bbdd85bd15","name":"RHEL8 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":970.096478,"created":"2025-05-02T10:06:43.597176","updated":"2025-05-02T10:06:43.597182","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cad2c71-4a21-4bc5-9828-c3bbdd85bd15\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8cad2c71-4a21-4bc5-9828-c3bbdd85bd15/pipeline.log\">pipeline</a>"]},{"id":"42bc45e6-6af5-4c90-a336-f57a0c0df5c8","name":"RHEL8 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":974.609285,"created":"2025-05-02T10:06:52.280760","updated":"2025-05-02T10:06:52.280766","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/42bc45e6-6af5-4c90-a336-f57a0c0df5c8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/42bc45e6-6af5-4c90-a336-f57a0c0df5c8/pipeline.log\">pipeline</a>"]},{"id":"0215b4c1-888b-4ebc-b9f8-1a0d9913cad8","name":"RHEL9 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1004.29266,"created":"2025-05-02T10:06:42.272502","updated":"2025-05-02T10:06:42.272510","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0215b4c1-888b-4ebc-b9f8-1a0d9913cad8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0215b4c1-888b-4ebc-b9f8-1a0d9913cad8/pipeline.log\">pipeline</a>"]},{"id":"48e01ae1-a1c1-4b35-af96-4ad159ad5e1d","name":"RHEL9 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1021.086207,"created":"2025-05-02T10:06:41.165944","updated":"2025-05-02T10:06:41.165950","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/48e01ae1-a1c1-4b35-af96-4ad159ad5e1d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/48e01ae1-a1c1-4b35-af96-4ad159ad5e1d/pipeline.log\">pipeline</a>"]},{"id":"372d2569-3076-4504-b6c6-a23074033cbd","name":"RHEL8 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1387.155891,"created":"2025-05-02T10:06:50.722614","updated":"2025-05-02T10:06:50.722620","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/372d2569-3076-4504-b6c6-a23074033cbd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/372d2569-3076-4504-b6c6-a23074033cbd/pipeline.log\">pipeline</a>"]},{"id":"4332b086-b22b-485f-b7d8-2e3322deb1e4","name":"RHEL8 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1418.417632,"created":"2025-05-02T10:06:47.418942","updated":"2025-05-02T10:06:47.418947","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4332b086-b22b-485f-b7d8-2e3322deb1e4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4332b086-b22b-485f-b7d8-2e3322deb1e4/pipeline.log\">pipeline</a>"]},{"id":"2502cbd5-2356-44f3-af0c-fb2ab70b34cd","name":"RHEL10 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1803.307052,"created":"2025-05-02T10:06:42.602138","updated":"2025-05-02T10:06:42.602144","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2502cbd5-2356-44f3-af0c-fb2ab70b34cd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2502cbd5-2356-44f3-af0c-fb2ab70b34cd/pipeline.log\">pipeline</a>"]},{"id":"4a457f46-6858-402e-bb24-0b1e7575a53b","name":"RHEL8 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1815.907931,"created":"2025-05-02T10:06:42.745859","updated":"2025-05-02T10:06:42.745864","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4a457f46-6858-402e-bb24-0b1e7575a53b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4a457f46-6858-402e-bb24-0b1e7575a53b/pipeline.log\">pipeline</a>"]},{"id":"3adb0b57-145d-4f41-a60a-4bc57cb638cd","name":"RHEL9 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1865.428128,"created":"2025-05-02T10:06:57.056879","updated":"2025-05-02T10:06:57.056886","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3adb0b57-145d-4f41-a60a-4bc57cb638cd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3adb0b57-145d-4f41-a60a-4bc57cb638cd/pipeline.log\">pipeline</a>"]},{"id":"9cf39d41-f9b6-4469-afca-1bd8e38d1064","name":"RHEL8 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1919.524145,"created":"2025-05-02T10:06:39.616551","updated":"2025-05-02T10:06:39.616556","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cf39d41-f9b6-4469-afca-1bd8e38d1064\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cf39d41-f9b6-4469-afca-1bd8e38d1064/pipeline.log\">pipeline</a>"]},{"id":"7db36c9f-683c-423d-aab8-ab771d71ff53","name":"RHEL8 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1932.285573,"created":"2025-05-02T10:06:41.974378","updated":"2025-05-02T10:06:41.974383","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7db36c9f-683c-423d-aab8-ab771d71ff53\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7db36c9f-683c-423d-aab8-ab771d71ff53/pipeline.log\">pipeline</a>"]},{"id":"c424777b-2dfb-4dff-bbc7-7767cd3e73f0","name":"RHEL9 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1933.300978,"created":"2025-05-02T10:06:39.670711","updated":"2025-05-02T10:06:39.670717","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c424777b-2dfb-4dff-bbc7-7767cd3e73f0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c424777b-2dfb-4dff-bbc7-7767cd3e73f0/pipeline.log\">pipeline</a>"]},{"id":"82b41267-2339-4b0c-9779-d1b21e4cdb9d","name":"RHEL9 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":2030.515724,"created":"2025-05-02T10:06:40.197555","updated":"2025-05-02T10:06:40.197561","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/82b41267-2339-4b0c-9779-d1b21e4cdb9d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/82b41267-2339-4b0c-9779-d1b21e4cdb9d/pipeline.log\">pipeline</a>"]},{"id":"b6aa94cb-6de0-4bea-9a6e-eb65b89d55eb","name":"RHEL10 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1210.67793,"created":"2025-05-02T10:21:02.193989","updated":"2025-05-02T10:21:02.193995","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6aa94cb-6de0-4bea-9a6e-eb65b89d55eb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6aa94cb-6de0-4bea-9a6e-eb65b89d55eb/pipeline.log\">pipeline</a>"]},{"id":"01f2c7ad-4905-47b1-9743-12a45ba01922","name":"RHEL10 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1262.179842,"created":"2025-05-02T10:23:00.691526","updated":"2025-05-02T10:23:00.691532","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01f2c7ad-4905-47b1-9743-12a45ba01922\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01f2c7ad-4905-47b1-9743-12a45ba01922/pipeline.log\">pipeline</a>"]},{"id":"8ab206a5-b3fa-425b-bbc0-84dea615c5aa","name":"RHEL9 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1418.520633,"created":"2025-05-02T10:20:34.638880","updated":"2025-05-02T10:20:34.638889","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ab206a5-b3fa-425b-bbc0-84dea615c5aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ab206a5-b3fa-425b-bbc0-84dea615c5aa/pipeline.log\">pipeline</a>"]},{"id":"93ba2c1e-634b-4f8d-a705-b8e550415f81","name":"RHEL9 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1424.692857,"created":"2025-05-02T10:21:14.878871","updated":"2025-05-02T10:21:14.878876","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/93ba2c1e-634b-4f8d-a705-b8e550415f81\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/93ba2c1e-634b-4f8d-a705-b8e550415f81/pipeline.log\">pipeline</a>"]},{"id":"357817c5-d8cc-427d-84e4-a03738aa4a87","name":"RHEL9 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1389.160541,"created":"2025-05-02T10:22:01.031192","updated":"2025-05-02T10:22:01.031199","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/357817c5-d8cc-427d-84e4-a03738aa4a87\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/357817c5-d8cc-427d-84e4-a03738aa4a87/pipeline.log\">pipeline</a>"]},{"id":"9b7696de-3b9e-46a1-9cfb-7b5539edf149","name":"RHEL8 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1361.711775,"created":"2025-05-02T10:24:06.994434","updated":"2025-05-02T10:24:06.994440","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b7696de-3b9e-46a1-9cfb-7b5539edf149\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9b7696de-3b9e-46a1-9cfb-7b5539edf149/pipeline.log\">pipeline</a>"]},{"id":"4e924e1e-2a03-495f-8c0f-f4972fcbe0e8","name":"RHEL8 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1371.096109,"created":"2025-05-02T10:24:08.945461","updated":"2025-05-02T10:24:08.945466","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4e924e1e-2a03-495f-8c0f-f4972fcbe0e8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4e924e1e-2a03-495f-8c0f-f4972fcbe0e8/pipeline.log\">pipeline</a>"]},{"id":"347c51d9-fe2e-47d5-a51e-8bf172adaac6","name":"RHEL9 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1490.702573,"created":"2025-05-02T10:22:06.730521","updated":"2025-05-02T10:22:06.730528","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/347c51d9-fe2e-47d5-a51e-8bf172adaac6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/347c51d9-fe2e-47d5-a51e-8bf172adaac6/pipeline.log\">pipeline</a>"]},{"id":"928e7558-f5f5-433f-a2f3-042f274815a7","name":"RHEL9 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1381.866101,"created":"2025-05-02T10:24:33.163968","updated":"2025-05-02T10:24:33.163973","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/928e7558-f5f5-433f-a2f3-042f274815a7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/928e7558-f5f5-433f-a2f3-042f274815a7/pipeline.log\">pipeline</a>"]},{"id":"16cf5f02-6bf8-4074-9e35-be5ed2aaf633","name":"RHEL8 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1399.521605,"created":"2025-05-02T10:24:03.596303","updated":"2025-05-02T10:24:03.596309","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/16cf5f02-6bf8-4074-9e35-be5ed2aaf633\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/16cf5f02-6bf8-4074-9e35-be5ed2aaf633/pipeline.log\">pipeline</a>"]},{"id":"1922e3ad-6e8b-4e52-a4af-8279ca2408bf","name":"RHEL9 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1360.613732,"created":"2025-05-02T10:25:44.290912","updated":"2025-05-02T10:25:44.290917","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1922e3ad-6e8b-4e52-a4af-8279ca2408bf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1922e3ad-6e8b-4e52-a4af-8279ca2408bf/pipeline.log\">pipeline</a>"]},{"id":"4b7a5727-f84b-4883-814e-71a83d8858de","name":"RHEL8 - OpenShift 4 - 18-minimal","runTime":1351.370761,"created":"2025-05-02T10:30:46.812655","updated":"2025-05-02T10:30:46.812663","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b7a5727-f84b-4883-814e-71a83d8858de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4b7a5727-f84b-4883-814e-71a83d8858de/pipeline.log\">pipeline</a>"]}]} -->