### PR TITLE
Add rhel10 imagestreams

### DIFF
--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -16,6 +16,10 @@
 
       - name: UBI 9
         app_versions: ["20", "20-minimal", "22", "22-minimal"]
+
+      - name: UBI 10
+        app_versions: ["22", "22-minimal"]
+
     custom_tags:
       - name: "20-ubi8-minimal"
         distro: UBI 8
@@ -26,6 +30,9 @@
       - name: "22-ubi9-minimal"
         distro: UBI 9
         app_version: "22-minimal"
+      - name: "22-ubi10-minimal"
+        distro: UBI 10
+        app_version: "22-minimal"
 
   - filename: nodejs-rhel.json
     latest: "22-ubi9"
@@ -35,6 +42,10 @@
 
       - name: UBI 9
         app_versions: ["20", "20-minimal", "22", "22-minimal"]
+
+      - name: UBI 10
+        app_versions: ["22", "22-minimal"]
+
     # these are non standard tags, maintained for backwards compatibility
     custom_tags:
       - name: "20-ubi8-minimal"
@@ -46,6 +57,9 @@
       - name: "22-ubi9-minimal"
         distro: UBI 9
         app_version: "22-minimal"
+      - name: "22-ubi10-minimal"
+        distro: UBI 10
+        app_version: "22-minimal"
 
   - filename: nodejs-rhel-aarch64.json
     latest: "22-ubi9"
@@ -55,6 +69,10 @@
 
       - name: UBI 9
         app_versions: ["20", "20-minimal", "22", "22-minimal"]
+
+      - name: UBI 10
+        app_versions: ["22", "22-minimal"]
+
     custom_tags:
       - name: "20-ubi8-minimal"
         distro: UBI 8
@@ -64,5 +82,8 @@
         app_version: "20-minimal"
       - name: "22-ubi9-minimal"
         distro: UBI 9
+        app_version: "22-minimal"
+      - name: "22-ubi10-minimal"
+        distro: UBI 10
         app_version: "22-minimal"
 ...

--- a/imagestreams/nodejs-centos.json
+++ b/imagestreams/nodejs-centos.json
@@ -124,28 +124,6 @@
         }
       },
       {
-<<<<<<< HEAD
-||||||| parent of 15cc391 (Add support for the latest imagestreams in RHEL10.)
-        "name": "18-ubi8-minimal",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
-          "version": "18-minimal",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/nodejs-18-minimal:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-=======
         "name": "22-ubi10",
         "annotations": {
           "openshift.io/display-name": "Node.js 22 (UBI 10)",
@@ -184,26 +162,6 @@
         }
       },
       {
-        "name": "18-ubi8-minimal",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
-          "version": "18-minimal",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi8/nodejs-18-minimal:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
->>>>>>> 15cc391 (Add support for the latest imagestreams in RHEL10.)
         "name": "20-ubi8-minimal",
         "annotations": {
           "openshift.io/display-name": "Node.js 20-minimal (UBI 8)",

--- a/imagestreams/nodejs-centos.json
+++ b/imagestreams/nodejs-centos.json
@@ -124,6 +124,86 @@
         }
       },
       {
+<<<<<<< HEAD
+||||||| parent of 15cc391 (Add support for the latest imagestreams in RHEL10.)
+        "name": "18-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "18-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/nodejs-18-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+=======
+        "name": "22-ubi10",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi10/nodejs-22:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-minimal-ubi10",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi10/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "18-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "18-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/nodejs-18-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+>>>>>>> 15cc391 (Add support for the latest imagestreams in RHEL10.)
         "name": "20-ubi8-minimal",
         "annotations": {
           "openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
@@ -175,6 +255,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.access.redhat.com/ubi9/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-ubi10-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi10/nodejs-22-minimal:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nodejs-rhel-aarch64.json
+++ b/imagestreams/nodejs-rhel-aarch64.json
@@ -124,6 +124,86 @@
         }
       },
       {
+<<<<<<< HEAD
+||||||| parent of 15cc391 (Add support for the latest imagestreams in RHEL10.)
+        "name": "18-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "18-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+=======
+        "name": "22-ubi10",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi10/nodejs-22:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-minimal-ubi10",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi10/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "18-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "18-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+>>>>>>> 15cc391 (Add support for the latest imagestreams in RHEL10.)
         "name": "20-ubi8-minimal",
         "annotations": {
           "openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
@@ -175,6 +255,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi9/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-ubi10-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi10/nodejs-22-minimal:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nodejs-rhel-aarch64.json
+++ b/imagestreams/nodejs-rhel-aarch64.json
@@ -124,28 +124,6 @@
         }
       },
       {
-<<<<<<< HEAD
-||||||| parent of 15cc391 (Add support for the latest imagestreams in RHEL10.)
-        "name": "18-ubi8-minimal",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
-          "version": "18-minimal",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-=======
         "name": "22-ubi10",
         "annotations": {
           "openshift.io/display-name": "Node.js 22 (UBI 10)",
@@ -184,26 +162,6 @@
         }
       },
       {
-        "name": "18-ubi8-minimal",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
-          "version": "18-minimal",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
->>>>>>> 15cc391 (Add support for the latest imagestreams in RHEL10.)
         "name": "20-ubi8-minimal",
         "annotations": {
           "openshift.io/display-name": "Node.js 20-minimal (UBI 8)",

--- a/imagestreams/nodejs-rhel.json
+++ b/imagestreams/nodejs-rhel.json
@@ -124,6 +124,86 @@
         }
       },
       {
+<<<<<<< HEAD
+||||||| parent of 15cc391 (Add support for the latest imagestreams in RHEL10.)
+        "name": "18-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "18-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+=======
+        "name": "22-ubi10",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi10/nodejs-22:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-minimal-ubi10",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi10/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "18-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "18-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+>>>>>>> 15cc391 (Add support for the latest imagestreams in RHEL10.)
         "name": "20-ubi8-minimal",
         "annotations": {
           "openshift.io/display-name": "Node.js 20-minimal (UBI 8)",
@@ -175,6 +255,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi9/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-ubi10-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 10)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 10. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi10/nodejs-22-minimal:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nodejs-rhel.json
+++ b/imagestreams/nodejs-rhel.json
@@ -124,28 +124,6 @@
         }
       },
       {
-<<<<<<< HEAD
-||||||| parent of 15cc391 (Add support for the latest imagestreams in RHEL10.)
-        "name": "18-ubi8-minimal",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
-          "version": "18-minimal",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-=======
         "name": "22-ubi10",
         "annotations": {
           "openshift.io/display-name": "Node.js 22 (UBI 10)",
@@ -184,26 +162,6 @@
         }
       },
       {
-        "name": "18-ubi8-minimal",
-        "annotations": {
-          "openshift.io/display-name": "Node.js 18-minimal (UBI 8)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Node.js 18-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/18-minimal/README.md.",
-          "iconClass": "icon-nodejs",
-          "tags": "builder,nodejs",
-          "version": "18-minimal",
-          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi8/nodejs-18-minimal:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
->>>>>>> 15cc391 (Add support for the latest imagestreams in RHEL10.)
         "name": "20-ubi8-minimal",
         "annotations": {
           "openshift.io/display-name": "Node.js 20-minimal (UBI 8)",

--- a/test/constants.py
+++ b/test/constants.py
@@ -1,0 +1,5 @@
+TAGS = {
+    "rhel8": "-ubi8",
+    "rhel9": "-ubi9",
+    "rhel10": "-ubi10",
+}

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -340,19 +340,11 @@ test_incremental_build() {
   ct_check_testcase_result $?
   build_log2=$(ct_s2i_build_as_df file://${test_dir}/test-incremental ${IMAGE_NAME} ${IMAGE_NAME}-testapp ${s2i_args} ${npm_variables} --incremental)
   ct_check_testcase_result $?
-  if [ "$VERSION" == "6" ]; then
-      # Different npm output for version 6
-      if echo "$build_log2" | grep -e "\-\- yarn@[0-9\.]*"; then
-          echo "ERROR Incremental build failed: yarn package is getting installed in incremental build"
-          ct_check_testcase_result 1
-      fi
-  else
-      first=$(echo "$build_log1" | grep -o -e "added [0-9]* packages" | awk '{ print $2 }')
-      second=$(echo "$build_log2" | grep -o -e "added [0-9]* packages" | awk '{ print $2 }')
-      if [ "$first" == "$second" ]; then
-          echo "ERROR Incremental build failed: both builds installed $first packages"
-          ct_check_testcase_result 1
-      fi
+  first=$(echo "$build_log1" | grep -o -e "added [0-9]* packages" | awk '{ print $2 }')
+  second=$(echo "$build_log2" | grep -o -e "added [0-9]* packages" | awk '{ print $2 }')
+  if [ "$first" == "$second" ]; then
+      echo "ERROR Incremental build failed: both builds installed $first packages"
+      ct_check_testcase_result 1
   fi
 
 }

--- a/test/test_imagestreams_quickstart.py
+++ b/test/test_imagestreams_quickstart.py
@@ -13,7 +13,7 @@ if not check_variables():
     sys.exit(1)
 
 
-VERSION = os.getenv("VERSION")
+VERSION = os.getenv("VERSION").replace("-minimal", "")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("OS")
 
@@ -29,7 +29,7 @@ IMAGE_TAG = f"15-c9s"
 class TestImagestreamsQuickstart:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="nodejs-example", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=f"nodejs-{VERSION}-example", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()
@@ -43,29 +43,26 @@ class TestImagestreamsQuickstart:
     )
     def test_nodejs_template_inside_cluster(self, template):
         assert self.oc_api.upload_image(DEPLOYED_PGSQL_IMAGE, PGSQL_IMAGE_TAG)
-        new_version = VERSION
-        if "minimal" in VERSION:
-            new_version = VERSION.replace("-minimal", "")
-        service_name = f"nodejs-{new_version}-example"
+        service_name = f"nodejs-{VERSION}-example"
         template_url = self.oc_api.get_raw_url_for_json(
             container="nodejs-ex", dir="openshift/templates", filename=template, branch="master"
         )
         openshift_args = [
-            f"SOURCE_REPOSITORY_URL=https://github.com/sclorg/nodejs-ex.git",
-            f"SOURCE_REPOSITORY_REF=master",
-            f"NODEJS_VERSION={new_version}",
+            "SOURCE_REPOSITORY_URL=https://github.com/sclorg/nodejs-ex.git",
+            "SOURCE_REPOSITORY_REF=master",
+            f"NODEJS_VERSION={VERSION}",
             f"NAME={service_name}"
         ]
         if template != "nodejs.json":
             openshift_args = [
-                f"SOURCE_REPOSITORY_URL=https://github.com/sclorg/nodejs-ex.git",
-                f"SOURCE_REPOSITORY_REF=master",
+                "SOURCE_REPOSITORY_URL=https://github.com/sclorg/nodejs-ex.git",
+                "SOURCE_REPOSITORY_REF=master",
                 f"POSTGRESQL_VERSION={IMAGE_TAG}",
-                f"NODEJS_VERSION={new_version}",
+                f"NODEJS_VERSION={VERSION}",
                 f"NAME={service_name}",
-                f"DATABASE_USER=testu",
-                f"DATABASE_PASSWORD=testpwd",
-                f"DATABASE_ADMIN_PASSWORD=testadminpwd"
+                "DATABASE_USER=testu",
+                "DATABASE_PASSWORD=testpwd",
+                "DATABASE_ADMIN_PASSWORD=testadminpwd"
             ]
         assert self.oc_api.imagestream_quickstart(
             imagestream_file="imagestreams/nodejs-rhel.json",

--- a/test/test_nodejs_ex_standalone.py
+++ b/test/test_nodejs_ex_standalone.py
@@ -19,13 +19,16 @@ OS = os.getenv("TARGET")
 class TestNodeJSExTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="nodejs-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix="nodejs-testing", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     def test_nodejs_ex_template_inside_cluster(self):
-        service_name = "nodejs-testing"
+        new_version = VERSION
+        if "minimal" in VERSION:
+            new_version = VERSION.replace("-minimal", "")
+        service_name = f"nodejs-{new_version}-testing"
         assert self.oc_api.deploy_s2i_app(
             image_name=IMAGE_NAME, app=f"https://github.com/sclorg/nodejs-ex.git",
             context=".",

--- a/test/test_nodejs_ex_standalone.py
+++ b/test/test_nodejs_ex_standalone.py
@@ -11,7 +11,7 @@ if not check_variables():
     sys.exit(1)
 
 
-VERSION = os.getenv("VERSION")
+VERSION = os.getenv("VERSION").replace("-minimal", "")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
 
@@ -19,16 +19,13 @@ OS = os.getenv("TARGET")
 class TestNodeJSExTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="nodejs-testing", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=f"nodejs-{VERSION}-testing", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     def test_nodejs_ex_template_inside_cluster(self):
-        new_version = VERSION
-        if "minimal" in VERSION:
-            new_version = VERSION.replace("-minimal", "")
-        service_name = f"nodejs-{new_version}-testing"
+        service_name = f"nodejs-{VERSION}-testing"
         assert self.oc_api.deploy_s2i_app(
             image_name=IMAGE_NAME, app=f"https://github.com/sclorg/nodejs-ex.git",
             context=".",

--- a/test/test_nodejs_ex_templates.py
+++ b/test/test_nodejs_ex_templates.py
@@ -12,7 +12,7 @@ if not check_variables():
     sys.exit(1)
 
 
-VERSION = os.getenv("VERSION")
+VERSION = os.getenv("VERSION").replace("-minimal", "")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
 
@@ -27,7 +27,7 @@ IMAGE_TAG = f"15-c9s"
 class TestDeployNodeJSExTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="nodejs-testing", version=VERSION, shared_cluster=True)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=f"nodejs-{VERSION}-testing", version=VERSION, shared_cluster=True)
 
     def teardown_method(self):
         self.oc_api.delete_project()
@@ -44,14 +44,11 @@ class TestDeployNodeJSExTemplate:
         template_url = self.oc_api.get_raw_url_for_json(
             container="nodejs-ex", dir="openshift/templates", filename=template, branch="master"
         )
-        new_version = VERSION
-        if "minimal" in VERSION:
-            new_version = VERSION.replace("-minimal", "")
-        service_name = f"nodejs-{new_version}-testing"
+        service_name = f"nodejs-{VERSION}-testing"
         openshift_args = [
             "SOURCE_REPOSITORY_URL=https://github.com/sclorg/nodejs-ex.git",
             "SOURCE_REPOSITORY_REF=master",
-            f"NODEJS_VERSION={new_version}",
+            f"NODEJS_VERSION={VERSION}",
             f"NAME={service_name}"
         ]
         if template != "nodejs.json":
@@ -59,7 +56,7 @@ class TestDeployNodeJSExTemplate:
                 "SOURCE_REPOSITORY_URL=https://github.com/sclorg/nodejs-ex.git",
                 "SOURCE_REPOSITORY_REF=master",
                 f"POSTGRESQL_VERSION={IMAGE_TAG}",
-                f"NODEJS_VERSION={new_version}",
+                f"NODEJS_VERSION={VERSION}",
                 f"NAME={service_name}",
                 "DATABASE_USER=testu",
                 "DATABASE_PASSWORD=testpwd",

--- a/test/test_nodejs_s2i_standalone.py
+++ b/test/test_nodejs_s2i_standalone.py
@@ -11,24 +11,20 @@ if not check_variables():
     sys.exit(1)
 
 
-VERSION = os.getenv("VERSION")
+VERSION = os.getenv("VERSION").replace("-minimal", "")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
-
 
 class TestNodeJSExTemplate:
 
     def setup_method(self):
-        self.oc_api = OpenShiftAPI(pod_name_prefix="nodejs-testing", version=VERSION)
+        self.oc_api = OpenShiftAPI(pod_name_prefix=f"nodejs-{VERSION}-testing", version=VERSION)
 
     def teardown_method(self):
         self.oc_api.delete_project()
 
     def test_nodejs_ex_template_inside_cluster(self):
-        new_version = VERSION
-        if "minimal" in VERSION:
-            new_version = VERSION.replace("-minimal", "")
-        service_name = f"nodejs-{new_version}-testing"
+        service_name = f"nodejs-{VERSION}-testing"
         assert self.oc_api.deploy_s2i_app(
             image_name=IMAGE_NAME, app=f"https://github.com/sclorg/s2i-nodejs-container.git",
             context="test/test-app",

--- a/test/test_nodejs_s2i_standalone.py
+++ b/test/test_nodejs_s2i_standalone.py
@@ -25,7 +25,10 @@ class TestNodeJSExTemplate:
         self.oc_api.delete_project()
 
     def test_nodejs_ex_template_inside_cluster(self):
-        service_name = "nodejs-testing"
+        new_version = VERSION
+        if "minimal" in VERSION:
+            new_version = VERSION.replace("-minimal", "")
+        service_name = f"nodejs-{new_version}-testing"
         assert self.oc_api.deploy_s2i_app(
             image_name=IMAGE_NAME, app=f"https://github.com/sclorg/s2i-nodejs-container.git",
             context="test/test-app",

--- a/test/test_shared_helm_nodejs_application.py
+++ b/test/test_shared_helm_nodejs_application.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from container_ci_suite.helm import HelmChartsAPI
 from container_ci_suite.utils import check_variables
 
+from constants import TAGS
+
 if not check_variables():
     print("At least one variable from IMAGE_NAME, OS, VERSION is missing.")
     sys.exit(1)
@@ -17,11 +19,7 @@ VERSION = os.getenv("VERSION")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
 
-TAGS = {
-    "rhel8": "-ubi8",
-    "rhel9": "-ubi9"
-}
-TAG = TAGS.get(OS, None)
+TAG = TAGS.get(OS)
 
 
 class TestHelmNodeJSApplication:

--- a/test/test_shared_helm_nodejs_imagestreams.py
+++ b/test/test_shared_helm_nodejs_imagestreams.py
@@ -31,6 +31,8 @@ class TestHelmRHELNodeJSImageStreams:
     @pytest.mark.parametrize(
         "version,registry,expected",
         [
+            ("22-ubi10", "registry.redhat.io/ubi10/nodejs-22:latest", True),
+            ("22-ubi10-minimal", "registry.redhat.io/ubi10/nodejs-22-minimal:latest", True),
             ("22-ubi9", "registry.redhat.io/ubi9/nodejs-22:latest", True),
             ("22-ubi9-minimal", "registry.redhat.io/ubi9/nodejs-22-minimal:latest", True),
             ("20-ubi9", "registry.redhat.io/ubi9/nodejs-20:latest", True),


### PR DESCRIPTION
Adds testing RHEL10 imagestreams
and remove obsoleted VEERSIONS=6

<!-- issue-commentator = {"comment-id":"2882976103"} -->

<!-- testing-farm = {"lock":"true","comment-id":"2901674791","data":[{"id":"21381ba7-2053-49f7-b3b3-dc9605719ec0","name":"RHEL8 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":732.574949,"created":"2025-05-22T15:17:54.924721","updated":"2025-05-22T15:17:54.924727","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/21381ba7-2053-49f7-b3b3-dc9605719ec0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/21381ba7-2053-49f7-b3b3-dc9605719ec0/pipeline.log\">pipeline</a>"]},{"id":"439c51d2-8c78-47ae-87f3-2494180ffb4a","name":"RHEL8 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":720.782437,"created":"2025-05-22T15:18:42.961525","updated":"2025-05-22T15:18:42.961531","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/439c51d2-8c78-47ae-87f3-2494180ffb4a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/439c51d2-8c78-47ae-87f3-2494180ffb4a/pipeline.log\">pipeline</a>"]},{"id":"8b91dcf8-bbfa-490e-94e2-11c09e608f0b","name":"RHEL9 - PyTest - OpenShift 4 - 16-minimal","status":"complete","outcome":"passed","runTime":763.456554,"created":"2025-05-22T15:19:51.677903","updated":"2025-05-22T15:19:51.677914","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8b91dcf8-bbfa-490e-94e2-11c09e608f0b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8b91dcf8-bbfa-490e-94e2-11c09e608f0b/pipeline.log\">pipeline</a>"]},{"id":"30658346-f0d4-4d1b-ad91-b9db6c455fa2","name":"RHEL9 - PyTest - OpenShift 4 - 16","status":"complete","outcome":"passed","runTime":755.0606,"created":"2025-05-22T15:20:05.888388","updated":"2025-05-22T15:20:05.888395","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/30658346-f0d4-4d1b-ad91-b9db6c455fa2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/30658346-f0d4-4d1b-ad91-b9db6c455fa2/pipeline.log\">pipeline</a>"]},{"id":"c15afe81-e9c6-41ad-bb82-e8b9cac2ecc9","name":"RHEL8 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1343.413065,"created":"2025-05-22T15:15:31.737915","updated":"2025-05-22T15:15:31.737923","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c15afe81-e9c6-41ad-bb82-e8b9cac2ecc9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c15afe81-e9c6-41ad-bb82-e8b9cac2ecc9/pipeline.log\">pipeline</a>"]},{"id":"f3c52535-dd0a-46b9-ab58-e4a02d6c2299","name":"RHEL8 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":894.656146,"created":"2025-05-22T15:23:57.012317","updated":"2025-05-22T15:23:57.012323","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f3c52535-dd0a-46b9-ab58-e4a02d6c2299\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f3c52535-dd0a-46b9-ab58-e4a02d6c2299/pipeline.log\">pipeline</a>"]},{"id":"b106ea34-77ca-4bb2-ad19-93e5c3dacb2c","name":"RHEL8 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1298.141557,"created":"2025-05-22T15:17:57.621573","updated":"2025-05-22T15:17:57.621584","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b106ea34-77ca-4bb2-ad19-93e5c3dacb2c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b106ea34-77ca-4bb2-ad19-93e5c3dacb2c/pipeline.log\">pipeline</a>"]},{"id":"bdf1eb98-ec1f-4028-a576-a58ae2cb1762","name":"RHEL9 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1327.902991,"created":"2025-05-22T15:17:41.109575","updated":"2025-05-22T15:17:41.109583","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdf1eb98-ec1f-4028-a576-a58ae2cb1762\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdf1eb98-ec1f-4028-a576-a58ae2cb1762/pipeline.log\">pipeline</a>"]},{"id":"38b97be6-5468-4d0d-bb0f-9437e6d50069","name":"RHEL8 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1234.934087,"created":"2025-05-22T15:18:52.459215","updated":"2025-05-22T15:18:52.459222","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/38b97be6-5468-4d0d-bb0f-9437e6d50069\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/38b97be6-5468-4d0d-bb0f-9437e6d50069/pipeline.log\">pipeline</a>"]},{"id":"f61d842d-db10-43cd-8b14-2289c8dac18f","name":"RHEL8 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1301.747033,"created":"2025-05-22T15:18:00.987416","updated":"2025-05-22T15:18:00.987422","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f61d842d-db10-43cd-8b14-2289c8dac18f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f61d842d-db10-43cd-8b14-2289c8dac18f/pipeline.log\">pipeline</a>"]},{"id":"137a0b71-381f-403b-8053-ed17a6e3cca4","name":"RHEL9 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1320.33793,"created":"2025-05-22T15:18:46.868874","updated":"2025-05-22T15:18:46.868881","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/137a0b71-381f-403b-8053-ed17a6e3cca4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/137a0b71-381f-403b-8053-ed17a6e3cca4/pipeline.log\">pipeline</a>"]},{"id":"31a49871-2193-4dc7-9b34-518600dc03de","name":"RHEL10 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1170.075205,"created":"2025-05-22T15:22:06.045340","updated":"2025-05-22T15:22:06.045347","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/31a49871-2193-4dc7-9b34-518600dc03de\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/31a49871-2193-4dc7-9b34-518600dc03de/pipeline.log\">pipeline</a>"]},{"id":"1779eab0-c2cd-4581-8eaa-019404b913a9","name":"RHEL9 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":884.35022,"created":"2025-05-22T15:31:11.606261","updated":"2025-05-22T15:31:11.606269","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1779eab0-c2cd-4581-8eaa-019404b913a9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1779eab0-c2cd-4581-8eaa-019404b913a9/pipeline.log\">pipeline</a>"]},{"id":"970d8dfa-fcaf-4605-8568-477d5ec92438","name":"RHEL8 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1279.161553,"created":"2025-05-22T15:26:11.592077","updated":"2025-05-22T15:26:11.592084","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/970d8dfa-fcaf-4605-8568-477d5ec92438\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/970d8dfa-fcaf-4605-8568-477d5ec92438/pipeline.log\">pipeline</a>"]},{"id":"c9f109b7-9569-4ad9-9ea0-6dbeb806f455","name":"RHEL9 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":887.334878,"created":"2025-05-22T15:33:49.971706","updated":"2025-05-22T15:33:49.971711","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c9f109b7-9569-4ad9-9ea0-6dbeb806f455\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c9f109b7-9569-4ad9-9ea0-6dbeb806f455/pipeline.log\">pipeline</a>"]},{"id":"e2cac68a-287d-4bc1-b4c1-3a86f02a5236","name":"RHEL8 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":926.856143,"created":"2025-05-22T15:33:30.604070","updated":"2025-05-22T15:33:30.604078","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e2cac68a-287d-4bc1-b4c1-3a86f02a5236\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e2cac68a-287d-4bc1-b4c1-3a86f02a5236/pipeline.log\">pipeline</a>"]},{"id":"c2c480f8-d39c-4b9a-ad6e-9bf1513581ed","name":"RHEL9 - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":1250.848109,"created":"2025-05-22T15:30:47.961545","updated":"2025-05-22T15:30:47.961551","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2c480f8-d39c-4b9a-ad6e-9bf1513581ed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2c480f8-d39c-4b9a-ad6e-9bf1513581ed/pipeline.log\">pipeline</a>"]},{"id":"2340d000-779a-4758-bdfc-30b098aa19d5","name":"RHEL10 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":716.897471,"created":"2025-05-22T15:42:09.582945","updated":"2025-05-22T15:42:09.582951","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2340d000-779a-4758-bdfc-30b098aa19d5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2340d000-779a-4758-bdfc-30b098aa19d5/pipeline.log\">pipeline</a>"]},{"id":"55b76f4b-6517-4b7a-9b8e-c99b750d9327","name":"RHEL9 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1289.13472,"created":"2025-05-22T15:33:27.512047","updated":"2025-05-22T15:33:27.512056","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/55b76f4b-6517-4b7a-9b8e-c99b750d9327\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/55b76f4b-6517-4b7a-9b8e-c99b750d9327/pipeline.log\">pipeline</a>"]},{"id":"9a82705b-ff62-42ba-9783-5dd7218aecc7","name":"RHEL9 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":969.994635,"created":"2025-05-22T15:39:19.309998","updated":"2025-05-22T15:39:19.310005","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9a82705b-ff62-42ba-9783-5dd7218aecc7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9a82705b-ff62-42ba-9783-5dd7218aecc7/pipeline.log\">pipeline</a>"]},{"id":"6bd7f343-5ba9-4929-9ced-9996d3de7bb4","name":"RHEL8 - PyTest - OpenShift 4 - 18-minimal","status":"complete","outcome":"passed","runTime":873.965016,"created":"2025-05-22T15:41:33.349072","updated":"2025-05-22T15:41:33.349078","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6bd7f343-5ba9-4929-9ced-9996d3de7bb4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6bd7f343-5ba9-4929-9ced-9996d3de7bb4/pipeline.log\">pipeline</a>"]},{"id":"89e22fd1-22c1-4636-8e8d-775d8452d4e7","name":"RHEL9 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1247.171338,"created":"2025-05-22T15:38:37.732329","updated":"2025-05-22T15:38:37.732337","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/89e22fd1-22c1-4636-8e8d-775d8452d4e7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/89e22fd1-22c1-4636-8e8d-775d8452d4e7/pipeline.log\">pipeline</a>"]},{"id":"1fcf3b32-9538-4b9b-8be4-3447aa81e1cc","name":"RHEL9 - OpenShift 4 - 18","status":"complete","outcome":"passed","runTime":1244.319321,"created":"2025-05-22T15:39:55.777093","updated":"2025-05-22T15:39:55.777098","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1fcf3b32-9538-4b9b-8be4-3447aa81e1cc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1fcf3b32-9538-4b9b-8be4-3447aa81e1cc/pipeline.log\">pipeline</a>"]},{"id":"e37e4c15-5aeb-431a-8725-410e3bf063ef","name":"RHEL8 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1298.60969,"created":"2025-05-22T15:40:15.477281","updated":"2025-05-22T15:40:15.477287","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e37e4c15-5aeb-431a-8725-410e3bf063ef\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e37e4c15-5aeb-431a-8725-410e3bf063ef/pipeline.log\">pipeline</a>"]},{"id":"f4cc855a-3586-4089-8471-05ba84ee20aa","name":"RHEL8 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"error","runTime":4618.974806,"created":"2025-05-22T15:16:02.788560","updated":"2025-05-22T15:16:02.788568","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4cc855a-3586-4089-8471-05ba84ee20aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4cc855a-3586-4089-8471-05ba84ee20aa/pipeline.log\">pipeline</a>"]},{"id":"001af5e8-53c2-45b2-9374-5984002f1e5e","name":"RHEL9 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"error","runTime":4642.236295,"created":"2025-05-22T15:17:19.945426","updated":"2025-05-22T15:17:19.945431","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/001af5e8-53c2-45b2-9374-5984002f1e5e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/001af5e8-53c2-45b2-9374-5984002f1e5e/pipeline.log\">pipeline</a>"]},{"id":"3d01ec1d-f6be-4f18-b887-3ef078db02a7","name":"RHEL9 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"error","runTime":4674.999291,"created":"2025-05-22T15:19:35.793611","updated":"2025-05-22T15:19:35.793617","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3d01ec1d-f6be-4f18-b887-3ef078db02a7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3d01ec1d-f6be-4f18-b887-3ef078db02a7/pipeline.log\">pipeline</a>"]},{"id":"cca3b1bd-7a4c-467d-9feb-634d479e9af2","name":"RHEL8 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"error","runTime":4586.301925,"created":"2025-05-22T15:21:23.647706","updated":"2025-05-22T15:21:23.647712","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cca3b1bd-7a4c-467d-9feb-634d479e9af2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cca3b1bd-7a4c-467d-9feb-634d479e9af2/pipeline.log\">pipeline</a>"]},{"id":"689f4409-cb3d-402a-aee9-925709dca629","name":"RHEL8 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"error","runTime":4669.009383,"created":"2025-05-22T15:26:59.701447","updated":"2025-05-22T15:26:59.701454","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/689f4409-cb3d-402a-aee9-925709dca629\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/689f4409-cb3d-402a-aee9-925709dca629/pipeline.log\">pipeline</a>"]},{"id":"e72c2244-2c8b-4036-a677-5b6e54f19a73","name":"RHEL10 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"error","runTime":4606.052512,"created":"2025-05-22T15:40:38.654887","updated":"2025-05-22T15:40:38.654895","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e72c2244-2c8b-4036-a677-5b6e54f19a73\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e72c2244-2c8b-4036-a677-5b6e54f19a73/pipeline.log\">pipeline</a>"]},{"id":"bc86c99b-d50d-4c31-8c30-5248d15d5ff4","name":"RHEL9 - PyTest - OpenShift 4 - 18","status":"complete","outcome":"error","runTime":4653.809826,"created":"2025-05-22T15:41:55.996726","updated":"2025-05-22T15:41:55.996732","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bc86c99b-d50d-4c31-8c30-5248d15d5ff4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bc86c99b-d50d-4c31-8c30-5248d15d5ff4/pipeline.log\">pipeline</a>"]},{"id":"a27ddae1-ac1f-4068-aac2-e12df483cc48","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":389.844256,"created":"2025-05-26T08:24:09.532201","updated":"2025-05-26T08:24:09.532208","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a27ddae1-ac1f-4068-aac2-e12df483cc48\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a27ddae1-ac1f-4068-aac2-e12df483cc48/pipeline.log\">pipeline</a>"]},{"id":"e7b44530-fe4d-4e18-8104-6d300a8e06aa","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":548.274021,"created":"2025-05-26T08:26:19.020968","updated":"2025-05-26T08:26:19.020974","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e7b44530-fe4d-4e18-8104-6d300a8e06aa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e7b44530-fe4d-4e18-8104-6d300a8e06aa/pipeline.log\">pipeline</a>"]},{"id":"af5813c4-cf98-420a-8190-af15a22fcf1c","name":"RHEL10 - 22-minimal","status":"complete","outcome":"error","runTime":685.323981,"created":"2025-05-26T08:24:13.811681","updated":"2025-05-26T08:24:13.811688","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/af5813c4-cf98-420a-8190-af15a22fcf1c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/af5813c4-cf98-420a-8190-af15a22fcf1c/pipeline.log\">pipeline</a>"]},{"id":"01b635b4-99bb-435b-b181-5c6906093f5f","name":"RHEL10 - UpstreamTests - 22-minimal","status":"complete","outcome":"passed","runTime":714.929743,"created":"2025-05-26T08:25:02.879143","updated":"2025-05-26T08:25:02.879150","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01b635b4-99bb-435b-b181-5c6906093f5f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01b635b4-99bb-435b-b181-5c6906093f5f/pipeline.log\">pipeline</a>"]},{"id":"7df5974e-82bb-4723-a11b-8bc5b2db4742","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":507.551706,"created":"2025-05-26T08:29:31.266497","updated":"2025-05-26T08:29:31.266504","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7df5974e-82bb-4723-a11b-8bc5b2db4742\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7df5974e-82bb-4723-a11b-8bc5b2db4742/pipeline.log\">pipeline</a>"]},{"id":"94efcfa1-2564-4f6b-bb6c-da3b3b216ee7","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":483.232567,"created":"2025-05-26T08:30:03.074250","updated":"2025-05-26T08:30:03.074256","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/94efcfa1-2564-4f6b-bb6c-da3b3b216ee7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/94efcfa1-2564-4f6b-bb6c-da3b3b216ee7/pipeline.log\">pipeline</a>"]},{"id":"88f9d2c2-bf80-4924-bd4b-bb11a7a2e8fa","name":"Fedora - 18-minimal","runTime":554.118465,"created":"2025-05-26T08:29:28.030907","updated":"2025-05-26T08:29:28.030913","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/88f9d2c2-bf80-4924-bd4b-bb11a7a2e8fa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/88f9d2c2-bf80-4924-bd4b-bb11a7a2e8fa/pipeline.log\">pipeline</a>"]}]} -->