### PR TITLE
Fix regular expression for getting rhel name from rhel10 string

### DIFF
--- a/.github/workflows/container-fips-tests.yml
+++ b/.github/workflows/container-fips-tests.yml
@@ -1,0 +1,31 @@
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  container-tests:
+    # This job only runs for '[test]' pull request comments by owner, member
+    name: "Container tests with FIPS enabled: ${{ matrix.version }} - ${{ matrix.os_test }}"
+    runs-on: ubuntu-latest
+    concurrency:
+      group: container-fips-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ "20", "20-minimal", "22", "22-minimal" ]
+        os_test: [ "rhel9", "rhel10"  ]
+        test_case: [ "container-fips" ]
+
+    if: |
+      github.event.issue.pull_request
+      && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))
+      && contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    steps:
+      - uses: sclorg/tfaga-wrapper@main
+        with:
+          os_test: ${{ matrix.os_test }}
+          version: ${{ matrix.version }}
+          test_case: ${{ matrix.test_case }}
+          public_api_key: ${{ secrets.TF_PUBLIC_API_KEY }}
+          private_api_key: ${{ secrets.TF_INTERNAL_API_KEY }}

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -616,7 +616,7 @@ function test_nodejs_imagestream() {
     VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)
   fi
   ct_os_test_image_stream_quickstart \
-    "${THISDIR}/imagestreams/nodejs-${OS%[0-9]*}.json" \
+    "${THISDIR}/imagestreams/nodejs-${OS//[0-9]/}.json" \
     "https://raw.githubusercontent.com/sclorg/nodejs-ex/${BRANCH_TO_TEST}/openshift/templates/nodejs-postgresql-persistent.json" \
     "${IMAGE_NAME}" \
     'nodejs' \


### PR DESCRIPTION
Fix regular expression for getting rhel name from rhel10 string
The original regular returns 'rhel1' instead of 'rhel'.

<!-- testing-farm = {"lock":"false","comment-id":"2965795060","data":[{"id":"05a6b167-9976-453f-b436-5649118bcca6","name":"RHEL8 - PyTest - OpenShift 4 - 22","runTime":1667.330652,"created":"2025-06-18T11:43:34.762674","updated":"2025-06-18T11:43:34.762680","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/05a6b167-9976-453f-b436-5649118bcca6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/05a6b167-9976-453f-b436-5649118bcca6/pipeline.log\">pipeline</a>"]},{"id":"8405078b-6764-4d73-9fc8-fa1c35f159e0","name":"RHEL8 - 22","status":"complete","outcome":"error","runTime":741.870249,"created":"2025-06-18T10:22:32.080537","updated":"2025-06-18T10:22:32.080547","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8405078b-6764-4d73-9fc8-fa1c35f159e0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8405078b-6764-4d73-9fc8-fa1c35f159e0/pipeline.log\">pipeline</a>"]},{"id":"83313c93-533e-484a-94df-5d0b52b6c309","name":"RHEL9 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1051.669242,"created":"2025-06-17T14:06:50.883713","updated":"2025-06-17T14:06:50.883721","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/83313c93-533e-484a-94df-5d0b52b6c309\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/83313c93-533e-484a-94df-5d0b52b6c309/pipeline.log\">pipeline</a>"]},{"id":"0fdf8e2d-7ca0-45f8-892d-22b43412de7c","name":"RHEL9 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1835.74023,"created":"2025-06-17T14:08:45.304825","updated":"2025-06-17T14:08:45.304833","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0fdf8e2d-7ca0-45f8-892d-22b43412de7c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0fdf8e2d-7ca0-45f8-892d-22b43412de7c/pipeline.log\">pipeline</a>"]},{"id":"733f4b1a-842e-4cb3-b823-49082826f617","name":"RHEL8 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1213.763302,"created":"2025-06-17T13:56:41.773019","updated":"2025-06-17T13:56:41.773028","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/733f4b1a-842e-4cb3-b823-49082826f617\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/733f4b1a-842e-4cb3-b823-49082826f617/pipeline.log\">pipeline</a>"]},{"id":"6bc5460e-82c2-4f64-a35c-d5a2ea9d26c7","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1199.988105,"created":"2025-06-17T13:46:18.372562","updated":"2025-06-17T13:46:18.372569","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6bc5460e-82c2-4f64-a35c-d5a2ea9d26c7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6bc5460e-82c2-4f64-a35c-d5a2ea9d26c7/pipeline.log\">pipeline</a>"]},{"id":"9c779ae8-bee9-4330-84c6-1df84a961aa5","name":"RHEL10 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":825.852441,"created":"2025-06-18T11:43:34.677183","updated":"2025-06-18T11:43:34.677189","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c779ae8-bee9-4330-84c6-1df84a961aa5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9c779ae8-bee9-4330-84c6-1df84a961aa5/pipeline.log\">pipeline</a>"]},{"id":"8a6a079a-12c1-46b1-b195-ef30634a48b4","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":508.824351,"created":"2025-06-17T13:46:17.288712","updated":"2025-06-17T13:46:17.288720","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8a6a079a-12c1-46b1-b195-ef30634a48b4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8a6a079a-12c1-46b1-b195-ef30634a48b4/pipeline.log\">pipeline</a>"]},{"id":"d7d2a13d-bd3c-45ef-8b7c-a0593055c18c","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":666.796679,"created":"2025-06-17T13:46:26.069074","updated":"2025-06-17T13:46:26.069081","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d7d2a13d-bd3c-45ef-8b7c-a0593055c18c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d7d2a13d-bd3c-45ef-8b7c-a0593055c18c/pipeline.log\">pipeline</a>"]},{"id":"ee7551c2-285b-421a-9033-63cfe7824a70","name":"RHEL9 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1381.775122,"created":"2025-06-17T14:06:44.580066","updated":"2025-06-17T14:06:44.580073","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee7551c2-285b-421a-9033-63cfe7824a70\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ee7551c2-285b-421a-9033-63cfe7824a70/pipeline.log\">pipeline</a>"]},{"id":"feb07be7-b98f-44e1-96bc-ce22be96cb47","name":"RHEL9 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1425.456916,"created":"2025-06-17T08:52:01.184481","updated":"2025-06-17T08:52:01.184488","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/feb07be7-b98f-44e1-96bc-ce22be96cb47\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/feb07be7-b98f-44e1-96bc-ce22be96cb47/pipeline.log\">pipeline</a>"]},{"id":"7cc08c79-7bed-46c4-b24c-1fc13cf12828","name":"RHEL9 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":2058.856752,"created":"2025-06-17T13:56:51.973291","updated":"2025-06-17T13:56:51.973298","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7cc08c79-7bed-46c4-b24c-1fc13cf12828\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7cc08c79-7bed-46c4-b24c-1fc13cf12828/pipeline.log\">pipeline</a>"]},{"id":"31e6534c-051d-420b-886e-674ad33b63db","name":"RHEL10 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1648.25615,"created":"2025-06-17T14:00:39.619874","updated":"2025-06-17T14:00:39.619880","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/31e6534c-051d-420b-886e-674ad33b63db\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/31e6534c-051d-420b-886e-674ad33b63db/pipeline.log\">pipeline</a>"]},{"id":"01c349da-7e70-4b57-95a4-e6a71a41f007","name":"RHEL8 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1763.507801,"created":"2025-06-17T13:54:55.781486","updated":"2025-06-17T13:54:55.781492","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01c349da-7e70-4b57-95a4-e6a71a41f007\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01c349da-7e70-4b57-95a4-e6a71a41f007/pipeline.log\">pipeline</a>"]},{"id":"07d77796-cea6-4e30-8e84-c23c9784d3db","name":"RHEL8 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":871.617026,"created":"2025-06-18T11:43:37.144187","updated":"2025-06-18T11:43:37.144193","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/07d77796-cea6-4e30-8e84-c23c9784d3db\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/07d77796-cea6-4e30-8e84-c23c9784d3db/pipeline.log\">pipeline</a>"]},{"id":"ef2ecc8f-c2a4-4e26-b5b8-b6514d77d0f2","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":465.840947,"created":"2025-06-17T13:46:17.686557","updated":"2025-06-17T13:46:17.686563","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ef2ecc8f-c2a4-4e26-b5b8-b6514d77d0f2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ef2ecc8f-c2a4-4e26-b5b8-b6514d77d0f2/pipeline.log\">pipeline</a>"]},{"id":"01c4397f-89f3-4518-a147-2d310acd49b0","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":507.96921,"created":"2025-06-17T13:46:15.116247","updated":"2025-06-17T13:46:15.116254","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/01c4397f-89f3-4518-a147-2d310acd49b0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/01c4397f-89f3-4518-a147-2d310acd49b0/pipeline.log\">pipeline</a>"]},{"id":"c0b9383b-7e2a-45d6-8569-f1ef9879a7c6","name":"RHEL8 - 22-minimal","status":"complete","outcome":"passed","runTime":1022.483988,"created":"2025-06-18T11:43:24.659325","updated":"2025-06-18T11:43:24.659332","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0b9383b-7e2a-45d6-8569-f1ef9879a7c6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0b9383b-7e2a-45d6-8569-f1ef9879a7c6/pipeline.log\">pipeline</a>"]},{"id":"ef9b7eb6-99a3-44d8-8765-a817aa2405d2","name":"RHEL8 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":919.373609,"created":"2025-06-17T08:52:08.749768","updated":"2025-06-17T08:52:08.749775","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ef9b7eb6-99a3-44d8-8765-a817aa2405d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ef9b7eb6-99a3-44d8-8765-a817aa2405d2/pipeline.log\">pipeline</a>"]},{"id":"22a39eb9-2575-426f-ba97-38fcb50f7566","name":"RHEL8 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1292.132886,"created":"2025-06-18T11:43:43.521613","updated":"2025-06-18T11:43:43.521621","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/22a39eb9-2575-426f-ba97-38fcb50f7566\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/22a39eb9-2575-426f-ba97-38fcb50f7566/pipeline.log\">pipeline</a>"]},{"id":"bf67f89c-6b99-4902-8eff-8a8540f7ea79","name":"RHEL9 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1381.705224,"created":"2025-06-17T13:56:49.586177","updated":"2025-06-17T13:56:49.586185","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf67f89c-6b99-4902-8eff-8a8540f7ea79\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf67f89c-6b99-4902-8eff-8a8540f7ea79/pipeline.log\">pipeline</a>"]},{"id":"0125b9b4-0629-47bb-9255-51e1c352ea93","name":"RHEL9 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":969.119441,"created":"2025-06-17T13:56:47.758385","updated":"2025-06-17T13:56:47.758391","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0125b9b4-0629-47bb-9255-51e1c352ea93\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0125b9b4-0629-47bb-9255-51e1c352ea93/pipeline.log\">pipeline</a>"]},{"id":"568bdd4a-3860-4a30-aaef-99d18f653d9d","name":"RHEL8 - OpenShift 4 - 22-minimal","status":"complete","outcome":"error","runTime":377.52142,"created":"2025-06-18T11:43:45.068748","updated":"2025-06-18T11:43:45.068754","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/568bdd4a-3860-4a30-aaef-99d18f653d9d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/568bdd4a-3860-4a30-aaef-99d18f653d9d/pipeline.log\">pipeline</a>"]},{"id":"238a8425-567f-4438-9e2a-0c682d4d22f7","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":999.23455,"created":"2025-06-17T13:46:26.538013","updated":"2025-06-17T13:46:26.538021","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/238a8425-567f-4438-9e2a-0c682d4d22f7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/238a8425-567f-4438-9e2a-0c682d4d22f7/pipeline.log\">pipeline</a>"]},{"id":"f1a339aa-03f4-4c12-a934-2455ecab263c","name":"RHEL10 - 22-minimal","status":"complete","outcome":"passed","runTime":943.147874,"created":"2025-06-17T13:46:16.089821","updated":"2025-06-17T13:46:16.089828","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1a339aa-03f4-4c12-a934-2455ecab263c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f1a339aa-03f4-4c12-a934-2455ecab263c/pipeline.log\">pipeline</a>"]},{"id":"a213983b-c5d2-4013-8f25-28a8bbed2a52","name":"RHEL10 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1195.965355,"created":"2025-06-17T14:06:44.440591","updated":"2025-06-17T14:06:44.440600","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a213983b-c5d2-4013-8f25-28a8bbed2a52\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a213983b-c5d2-4013-8f25-28a8bbed2a52/pipeline.log\">pipeline</a>"]},{"id":"67da5764-60ca-4a19-b86c-518004ba7b66","name":"RHEL8 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1525.465919,"created":"2025-06-17T14:00:37.738810","updated":"2025-06-17T14:00:37.738817","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67da5764-60ca-4a19-b86c-518004ba7b66\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67da5764-60ca-4a19-b86c-518004ba7b66/pipeline.log\">pipeline</a>"]},{"id":"57fc5de3-0da5-48b8-98ec-a39bd52d9182","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":516.2849,"created":"2025-06-17T13:46:26.268298","updated":"2025-06-17T13:46:26.268307","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/57fc5de3-0da5-48b8-98ec-a39bd52d9182\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/57fc5de3-0da5-48b8-98ec-a39bd52d9182/pipeline.log\">pipeline</a>"]},{"id":"b715d8c1-7990-400d-9e8a-213f7d5a241e","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":547.596892,"created":"2025-06-17T13:46:24.298215","updated":"2025-06-17T13:46:24.298222","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b715d8c1-7990-400d-9e8a-213f7d5a241e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b715d8c1-7990-400d-9e8a-213f7d5a241e/pipeline.log\">pipeline</a>"]},{"id":"3ec2e7bb-42ef-4174-b880-00db21c4a3d2","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1167.926681,"created":"2025-06-17T08:51:47.166930","updated":"2025-06-17T08:51:47.166940","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ec2e7bb-42ef-4174-b880-00db21c4a3d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3ec2e7bb-42ef-4174-b880-00db21c4a3d2/pipeline.log\">pipeline</a>"]},{"id":"7847057d-100d-4f6f-8bce-758767c1899c","name":"RHEL9 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1848.507351,"created":"2025-06-17T13:46:39.278249","updated":"2025-06-17T13:46:39.278255","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7847057d-100d-4f6f-8bce-758767c1899c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7847057d-100d-4f6f-8bce-758767c1899c/pipeline.log\">pipeline</a>"]},{"id":"585b5e7d-2d35-41a2-b769-16c2040b2c0f","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":528.120309,"created":"2025-06-17T13:46:17.774508","updated":"2025-06-17T13:46:17.774517","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/585b5e7d-2d35-41a2-b769-16c2040b2c0f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/585b5e7d-2d35-41a2-b769-16c2040b2c0f/pipeline.log\">pipeline</a>"]},{"id":"99eb0aeb-6d5f-41cb-b87a-8c5b48b303cc","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":624.350347,"created":"2025-06-17T13:46:15.484674","updated":"2025-06-17T13:46:15.484683","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/99eb0aeb-6d5f-41cb-b87a-8c5b48b303cc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/99eb0aeb-6d5f-41cb-b87a-8c5b48b303cc/pipeline.log\">pipeline</a>"]},{"id":"5e4aa7a8-c9ca-4590-b15c-d9341da965be","name":"RHEL10 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1288.326246,"created":"2025-06-17T14:02:40.954985","updated":"2025-06-17T14:02:40.954992","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e4aa7a8-c9ca-4590-b15c-d9341da965be\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e4aa7a8-c9ca-4590-b15c-d9341da965be/pipeline.log\">pipeline</a>"]},{"id":"34266d57-1560-48e5-8238-524f80fd0310","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1256.88746,"created":"2025-06-17T13:46:22.841456","updated":"2025-06-17T13:46:22.841463","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/34266d57-1560-48e5-8238-524f80fd0310\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/34266d57-1560-48e5-8238-524f80fd0310/pipeline.log\">pipeline</a>"]},{"id":"b33d3ed3-06d3-4aa8-b494-21159c473985","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1098.25814,"created":"2025-06-17T13:46:15.792788","updated":"2025-06-17T13:46:15.792795","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b33d3ed3-06d3-4aa8-b494-21159c473985\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b33d3ed3-06d3-4aa8-b494-21159c473985/pipeline.log\">pipeline</a>"]},{"id":"566f5d9f-1a26-4c7e-9802-957dbc469bda","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":1188.268314,"created":"2025-06-17T13:46:17.890642","updated":"2025-06-17T13:46:17.890650","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/566f5d9f-1a26-4c7e-9802-957dbc469bda\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/566f5d9f-1a26-4c7e-9802-957dbc469bda/pipeline.log\">pipeline</a>"]},{"id":"5cb15ed1-30e3-4999-8233-33d8dd92445d","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":1232.387864,"created":"2025-06-17T13:46:16.899468","updated":"2025-06-17T13:46:16.899476","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5cb15ed1-30e3-4999-8233-33d8dd92445d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5cb15ed1-30e3-4999-8233-33d8dd92445d/pipeline.log\">pipeline</a>"]}]} -->