### PR TITLE
Add NodeJS 22 imagestreams for RHEL8

### DIFF
--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -12,7 +12,7 @@
     latest: "22-ubi9"
     distros:
       - name: UBI 8
-        app_versions: ["20", "20-minimal"]
+        app_versions: ["20", "20-minimal", "22", "22-minimal"]
 
       - name: UBI 9
         app_versions: ["20", "20-minimal", "22", "22-minimal"]
@@ -24,6 +24,9 @@
       - name: "20-ubi8-minimal"
         distro: UBI 8
         app_version: "20-minimal"
+      - name: "22-ubi8-minimal"
+        distro: UBI 8
+        app_version: "22-minimal"
       - name: "20-ubi9-minimal"
         distro: UBI 9
         app_version: "20-minimal"
@@ -38,7 +41,7 @@
     latest: "22-ubi9"
     distros:
       - name: UBI 8
-        app_versions: ["20", "20-minimal"]
+        app_versions: ["20", "20-minimal", "22", "22-minimal"]
 
       - name: UBI 9
         app_versions: ["20", "20-minimal", "22", "22-minimal"]
@@ -51,6 +54,9 @@
       - name: "20-ubi8-minimal"
         distro: UBI 8
         app_version: "20-minimal"
+      - name: "22-ubi8-minimal"
+        distro: UBI 8
+        app_version: "22-minimal"
       - name: "20-ubi9-minimal"
         distro: UBI 9
         app_version: "20-minimal"
@@ -65,7 +71,7 @@
     latest: "22-ubi9"
     distros:
       - name: UBI 8
-        app_versions: ["20", "20-minimal"]
+        app_versions: ["20", "20-minimal", "22", "22-minimal"]
 
       - name: UBI 9
         app_versions: ["20", "20-minimal", "22", "22-minimal"]
@@ -77,6 +83,9 @@
       - name: "20-ubi8-minimal"
         distro: UBI 8
         app_version: "20-minimal"
+      - name: "22-ubi8-minimal"
+        distro: UBI 8
+        app_version: "22-minimal"
       - name: "20-ubi9-minimal"
         distro: UBI 9
         app_version: "20-minimal"

--- a/imagestreams/nodejs-centos.json
+++ b/imagestreams/nodejs-centos.json
@@ -48,6 +48,44 @@
         }
       },
       {
+        "name": "22-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/nodejs-22:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-minimal-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "20-ubi9",
         "annotations": {
           "openshift.io/display-name": "Node.js 20 (UBI 9)",
@@ -175,6 +213,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.access.redhat.com/ubi8/nodejs-20-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.access.redhat.com/ubi8/nodejs-22-minimal:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nodejs-rhel-aarch64.json
+++ b/imagestreams/nodejs-rhel-aarch64.json
@@ -48,6 +48,44 @@
         }
       },
       {
+        "name": "22-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-22:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-minimal-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "20-ubi9",
         "annotations": {
           "openshift.io/display-name": "Node.js 20 (UBI 9)",
@@ -175,6 +213,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi8/nodejs-20-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-22-minimal:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/imagestreams/nodejs-rhel.json
+++ b/imagestreams/nodejs-rhel.json
@@ -48,6 +48,44 @@
         }
       },
       {
+        "name": "22-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-22:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-minimal-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-22-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
         "name": "20-ubi9",
         "annotations": {
           "openshift.io/display-name": "Node.js 20 (UBI 9)",
@@ -175,6 +213,25 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi8/nodejs-20-minimal:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "22-ubi8-minimal",
+        "annotations": {
+          "openshift.io/display-name": "Node.js 22-minimal (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Node.js 22-minimal applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-nodejs-container/blob/master/22-minimal/README.md.",
+          "iconClass": "icon-nodejs",
+          "tags": "builder,nodejs",
+          "version": "22-minimal",
+          "sampleRepo": "https://github.com/sclorg/nodejs-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/nodejs-22-minimal:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
See https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle#rhel8_application_streams for reference

<!-- testing-farm = {"lock":"false","comment-id":"3179635078","data":[{"id":"c038a33c-21df-4f95-9cce-ed7f973131a9","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":572.797638,"created":"2025-08-12T14:27:33.271375","updated":"2025-08-12T14:27:33.271381","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c038a33c-21df-4f95-9cce-ed7f973131a9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c038a33c-21df-4f95-9cce-ed7f973131a9/pipeline.log\">pipeline</a>"]},{"id":"9b3573d7-8f7d-4aae-9a0f-d5d1c034d815","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":699.930707,"created":"2025-08-12T14:27:33.119097","updated":"2025-08-12T14:27:33.119103","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9b3573d7-8f7d-4aae-9a0f-d5d1c034d815\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9b3573d7-8f7d-4aae-9a0f-d5d1c034d815/pipeline.log\">pipeline</a>"]},{"id":"5ace23ec-ac6d-48d8-b260-2c86cbcefc9a","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":603.751185,"created":"2025-08-12T14:27:33.417951","updated":"2025-08-12T14:27:33.417957","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5ace23ec-ac6d-48d8-b260-2c86cbcefc9a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5ace23ec-ac6d-48d8-b260-2c86cbcefc9a/pipeline.log\">pipeline</a>"]},{"id":"54562a6e-73f4-4041-b114-868068fe47f7","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":711.063359,"created":"2025-08-12T14:27:43.176030","updated":"2025-08-12T14:27:43.176036","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/54562a6e-73f4-4041-b114-868068fe47f7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/54562a6e-73f4-4041-b114-868068fe47f7/pipeline.log\">pipeline</a>"]},{"id":"c18612da-8318-46d0-a31e-fea8772c5215","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":1021.940711,"created":"2025-08-12T14:27:33.163807","updated":"2025-08-12T14:27:33.163815","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c18612da-8318-46d0-a31e-fea8772c5215\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c18612da-8318-46d0-a31e-fea8772c5215/pipeline.log\">pipeline</a>"]},{"id":"0dd14225-fc55-42b2-9ffc-f3f195f09974","name":"RHEL10 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1023.338508,"created":"2025-08-12T14:27:35.392775","updated":"2025-08-12T14:27:35.392786","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0dd14225-fc55-42b2-9ffc-f3f195f09974\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0dd14225-fc55-42b2-9ffc-f3f195f09974/pipeline.log\">pipeline</a>"]},{"id":"8e7efbaf-400a-4469-acb9-775e45e140d2","name":"RHEL8 - 22-minimal","status":"complete","outcome":"passed","runTime":1081.622476,"created":"2025-08-12T14:27:53.359215","updated":"2025-08-12T14:27:53.359223","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e7efbaf-400a-4469-acb9-775e45e140d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e7efbaf-400a-4469-acb9-775e45e140d2/pipeline.log\">pipeline</a>"]},{"id":"c3e23428-bc7f-460c-b007-28b0cdc01f21","name":"RHEL9 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1024.44002,"created":"2025-08-12T14:27:54.834778","updated":"2025-08-12T14:27:54.834784","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3e23428-bc7f-460c-b007-28b0cdc01f21\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3e23428-bc7f-460c-b007-28b0cdc01f21/pipeline.log\">pipeline</a>"]},{"id":"2f3fe9f9-6c44-4757-aff8-7ee99e303f5e","name":"RHEL10 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1120.734799,"created":"2025-08-12T14:27:43.369573","updated":"2025-08-12T14:27:43.369580","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f3fe9f9-6c44-4757-aff8-7ee99e303f5e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2f3fe9f9-6c44-4757-aff8-7ee99e303f5e/pipeline.log\">pipeline</a>"]},{"id":"81b59f5f-c5cc-46ef-bdea-29e2ac6ba11a","name":"Fedora - 24-minimal","status":"complete","outcome":"passed","runTime":394.659307,"created":"2025-08-12T14:41:12.310302","updated":"2025-08-12T14:41:12.310310","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/81b59f5f-c5cc-46ef-bdea-29e2ac6ba11a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/81b59f5f-c5cc-46ef-bdea-29e2ac6ba11a/pipeline.log\">pipeline</a>"]},{"id":"9204d9dd-33d5-43a3-a5f0-54a29db0afe7","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1298.026149,"created":"2025-08-12T14:27:34.757996","updated":"2025-08-12T14:27:34.758005","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9204d9dd-33d5-43a3-a5f0-54a29db0afe7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9204d9dd-33d5-43a3-a5f0-54a29db0afe7/pipeline.log\">pipeline</a>"]},{"id":"408be45d-cd27-493f-ab53-ee1e5406531c","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1334.020773,"created":"2025-08-12T14:27:35.769084","updated":"2025-08-12T14:27:35.769090","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/408be45d-cd27-493f-ab53-ee1e5406531c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/408be45d-cd27-493f-ab53-ee1e5406531c/pipeline.log\">pipeline</a>"]},{"id":"030a5ee1-05a0-492f-81e8-74be2ee9aff6","name":"RHEL9 - FIPS Enabled - 20","status":"complete","outcome":"passed","runTime":1556.646207,"created":"2025-08-12T14:27:33.343462","updated":"2025-08-12T14:27:33.343470","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/030a5ee1-05a0-492f-81e8-74be2ee9aff6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/030a5ee1-05a0-492f-81e8-74be2ee9aff6/pipeline.log\">pipeline</a>"]},{"id":"b9c87e77-2fd2-49db-95c4-0aeba1973ad5","name":"RHEL9 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1477.375984,"created":"2025-08-12T14:27:39.235558","updated":"2025-08-12T14:27:39.235564","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9c87e77-2fd2-49db-95c4-0aeba1973ad5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9c87e77-2fd2-49db-95c4-0aeba1973ad5/pipeline.log\">pipeline</a>"]},{"id":"f6e2c87f-7e04-4f28-821f-458afa7e5b7b","name":"RHEL9 - FIPS Enabled - 20-minimal","status":"complete","outcome":"passed","runTime":1465.684405,"created":"2025-08-12T14:27:40.505893","updated":"2025-08-12T14:27:40.505898","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6e2c87f-7e04-4f28-821f-458afa7e5b7b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6e2c87f-7e04-4f28-821f-458afa7e5b7b/pipeline.log\">pipeline</a>"]},{"id":"5adbaa78-eb7d-4a03-a6e9-eff8fac74654","name":"RHEL9 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1603.754095,"created":"2025-08-12T14:27:43.709327","updated":"2025-08-12T14:27:43.709336","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5adbaa78-eb7d-4a03-a6e9-eff8fac74654\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5adbaa78-eb7d-4a03-a6e9-eff8fac74654/pipeline.log\">pipeline</a>"]},{"id":"9aa829b4-7181-4efd-a25d-d388218d1990","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":1006.583589,"created":"2025-08-12T14:40:05.839133","updated":"2025-08-12T14:40:05.839141","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9aa829b4-7181-4efd-a25d-d388218d1990\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9aa829b4-7181-4efd-a25d-d388218d1990/pipeline.log\">pipeline</a>"]},{"id":"6ef1b4fe-9c94-4cf0-9a80-d138982b0b04","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1120.303389,"created":"2025-08-12T14:39:29.076678","updated":"2025-08-12T14:39:29.076685","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ef1b4fe-9c94-4cf0-9a80-d138982b0b04\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ef1b4fe-9c94-4cf0-9a80-d138982b0b04/pipeline.log\">pipeline</a>"]},{"id":"d4469202-1033-46ab-abee-7f188da9bb9d","name":"RHEL9 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1892.869967,"created":"2025-08-12T14:28:00.898059","updated":"2025-08-12T14:28:00.898067","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4469202-1033-46ab-abee-7f188da9bb9d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4469202-1033-46ab-abee-7f188da9bb9d/pipeline.log\">pipeline</a>"]},{"id":"70f3f46c-245d-4f21-a775-22554873e61b","name":"RHEL9 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1949.176282,"created":"2025-08-12T14:28:14.760400","updated":"2025-08-12T14:28:14.760405","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/70f3f46c-245d-4f21-a775-22554873e61b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/70f3f46c-245d-4f21-a775-22554873e61b/pipeline.log\">pipeline</a>"]},{"id":"32eabbff-7fea-4cb2-8b3e-d25401567eff","name":"RHEL8 - PyTest - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1672.654723,"created":"2025-08-12T14:37:53.775432","updated":"2025-08-12T14:37:53.775439","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/32eabbff-7fea-4cb2-8b3e-d25401567eff\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/32eabbff-7fea-4cb2-8b3e-d25401567eff/pipeline.log\">pipeline</a>"]},{"id":"96bd9863-25c4-4dd4-b1e1-ec0236597da5","name":"Fedora - 24","status":"complete","outcome":"passed","runTime":345.696092,"created":"2025-08-12T15:00:20.811437","updated":"2025-08-12T15:00:20.811444","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/96bd9863-25c4-4dd4-b1e1-ec0236597da5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/96bd9863-25c4-4dd4-b1e1-ec0236597da5/pipeline.log\">pipeline</a>"]},{"id":"e5791d1e-856a-4992-9453-857c4ce588f6","name":"RHEL8 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1222.8933,"created":"2025-08-12T14:46:14.460566","updated":"2025-08-12T14:46:14.460604","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e5791d1e-856a-4992-9453-857c4ce588f6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e5791d1e-856a-4992-9453-857c4ce588f6/pipeline.log\">pipeline</a>"]},{"id":"3790d5e3-f7ec-4220-a3ac-8bc5eda99e91","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":559.853635,"created":"2025-08-12T15:00:05.385844","updated":"2025-08-12T15:00:05.385855","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3790d5e3-f7ec-4220-a3ac-8bc5eda99e91\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3790d5e3-f7ec-4220-a3ac-8bc5eda99e91/pipeline.log\">pipeline</a>"]},{"id":"14e62ef4-9339-43f6-a53c-adb83a029d0c","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":634.087298,"created":"2025-08-12T14:58:31.910637","updated":"2025-08-12T14:58:31.910648","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/14e62ef4-9339-43f6-a53c-adb83a029d0c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/14e62ef4-9339-43f6-a53c-adb83a029d0c/pipeline.log\">pipeline</a>"]},{"id":"9e09066f-faa1-4ff9-934a-75a12093ce98","name":"RHEL10 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1064.375589,"created":"2025-08-12T14:54:08.337270","updated":"2025-08-12T14:54:08.337277","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e09066f-faa1-4ff9-934a-75a12093ce98\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e09066f-faa1-4ff9-934a-75a12093ce98/pipeline.log\">pipeline</a>"]},{"id":"7114d1e9-d5d5-49b8-b468-ccee53f34c41","name":"RHEL9 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1467.111125,"created":"2025-08-12T14:46:21.608643","updated":"2025-08-12T14:46:21.608655","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7114d1e9-d5d5-49b8-b468-ccee53f34c41\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7114d1e9-d5d5-49b8-b468-ccee53f34c41/pipeline.log\">pipeline</a>"]},{"id":"573ad686-838d-45c3-9d39-42dee500d96a","name":"RHEL9 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1517.880046,"created":"2025-08-12T14:47:58.991636","updated":"2025-08-12T14:47:58.991644","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/573ad686-838d-45c3-9d39-42dee500d96a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/573ad686-838d-45c3-9d39-42dee500d96a/pipeline.log\">pipeline</a>"]},{"id":"1c330693-6492-4dd8-9143-f653a62a1fb9","name":"RHEL10 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1333.188958,"created":"2025-08-12T14:49:55.631073","updated":"2025-08-12T14:49:55.631081","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1c330693-6492-4dd8-9143-f653a62a1fb9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1c330693-6492-4dd8-9143-f653a62a1fb9/pipeline.log\">pipeline</a>"]},{"id":"3a9cd641-7ac2-432d-b60a-2ac7d70cdda1","name":"RHEL9 - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1577.1407,"created":"2025-08-12T14:49:52.511179","updated":"2025-08-12T14:49:52.511185","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a9cd641-7ac2-432d-b60a-2ac7d70cdda1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3a9cd641-7ac2-432d-b60a-2ac7d70cdda1/pipeline.log\">pipeline</a>"]},{"id":"9e944614-da01-47f8-90df-710cec1708ff","name":"RHEL8 - PyTest - OpenShift 4 - 20-minimal","status":"complete","outcome":"passed","runTime":1231.274443,"created":"2025-08-12T14:56:10.731419","updated":"2025-08-12T14:56:10.731430","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e944614-da01-47f8-90df-710cec1708ff\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9e944614-da01-47f8-90df-710cec1708ff/pipeline.log\">pipeline</a>"]},{"id":"d36c516a-76f0-4516-8359-c82d8a1d213c","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1414.407271,"created":"2025-08-12T14:56:08.697812","updated":"2025-08-12T14:56:08.697820","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d36c516a-76f0-4516-8359-c82d8a1d213c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d36c516a-76f0-4516-8359-c82d8a1d213c/pipeline.log\">pipeline</a>"]},{"id":"ce2857cc-e2ed-4820-8916-f24a2e66420c","name":"RHEL8 - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1461.916158,"created":"2025-08-12T14:54:36.227889","updated":"2025-08-12T14:54:36.227898","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ce2857cc-e2ed-4820-8916-f24a2e66420c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ce2857cc-e2ed-4820-8916-f24a2e66420c/pipeline.log\">pipeline</a>"]},{"id":"7716e570-49e3-40c0-898e-38b6f69e62e3","name":"RHEL10 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1804.197923,"created":"2025-08-12T14:52:06.295400","updated":"2025-08-12T14:52:06.295410","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7716e570-49e3-40c0-898e-38b6f69e62e3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7716e570-49e3-40c0-898e-38b6f69e62e3/pipeline.log\">pipeline</a>"]},{"id":"6f1e454d-bf62-466e-8d6e-28291cf47ec2","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":763.396071,"created":"2025-08-12T15:08:55.456291","updated":"2025-08-12T15:08:55.456298","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6f1e454d-bf62-466e-8d6e-28291cf47ec2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6f1e454d-bf62-466e-8d6e-28291cf47ec2/pipeline.log\">pipeline</a>"]},{"id":"29261c54-d69b-43a4-bb22-ce9f6d849309","name":"RHEL9 - PyTest - OpenShift 4 - 22-minimal","status":"complete","outcome":"passed","runTime":1382.383319,"created":"2025-08-12T15:01:03.035757","updated":"2025-08-12T15:01:03.035765","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/29261c54-d69b-43a4-bb22-ce9f6d849309\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/29261c54-d69b-43a4-bb22-ce9f6d849309/pipeline.log\">pipeline</a>"]},{"id":"2db2248b-8a75-493e-a3d8-08385c1508d1","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":929.714698,"created":"2025-08-12T15:10:27.620773","updated":"2025-08-12T15:10:27.620780","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2db2248b-8a75-493e-a3d8-08385c1508d1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2db2248b-8a75-493e-a3d8-08385c1508d1/pipeline.log\">pipeline</a>"]},{"id":"7c70116e-74ca-4a10-b1dd-ec66be4809c8","name":"RHEL8 - PyTest - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1929.203199,"created":"2025-08-12T14:54:12.187906","updated":"2025-08-12T14:54:12.187915","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c70116e-74ca-4a10-b1dd-ec66be4809c8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c70116e-74ca-4a10-b1dd-ec66be4809c8/pipeline.log\">pipeline</a>"]},{"id":"29f61326-40ba-4599-b7d3-1afd32270878","name":"RHEL10 - 22-minimal","status":"complete","outcome":"passed","runTime":2583.714704,"created":"2025-08-12T14:46:01.530801","updated":"2025-08-12T14:46:01.530807","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/29f61326-40ba-4599-b7d3-1afd32270878\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/29f61326-40ba-4599-b7d3-1afd32270878/pipeline.log\">pipeline</a>"]},{"id":"18aab305-6277-4e5e-83d0-c083cfaaefe8","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":1806.722957,"created":"2025-08-12T15:02:41.352684","updated":"2025-08-12T15:02:41.352693","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/18aab305-6277-4e5e-83d0-c083cfaaefe8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/18aab305-6277-4e5e-83d0-c083cfaaefe8/pipeline.log\">pipeline</a>"]},{"id":"a690cf9b-df2e-4c7e-9033-34484a086f95","name":"RHEL9 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":3002.806746,"created":"2025-08-12T14:46:13.984877","updated":"2025-08-12T14:46:13.984883","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a690cf9b-df2e-4c7e-9033-34484a086f95\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a690cf9b-df2e-4c7e-9033-34484a086f95/pipeline.log\">pipeline</a>"]},{"id":"2b18092a-466f-4bde-9d43-8997b91a9e36","name":"RHEL8 - 22","status":"complete","outcome":"passed","runTime":1086.341225,"created":"2025-08-13T06:41:51.358863","updated":"2025-08-13T06:41:51.358870","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b18092a-466f-4bde-9d43-8997b91a9e36\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b18092a-466f-4bde-9d43-8997b91a9e36/pipeline.log\">pipeline</a>"]},{"id":"48c93e4f-93f9-48dc-b8a1-fd354276d3ce","name":"RHEL10 - OpenShift 4 - 22","status":"complete","outcome":"passed","runTime":1880.712596,"created":"2025-08-12T15:06:15.108775","updated":"2025-08-12T15:06:15.108781","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/48c93e4f-93f9-48dc-b8a1-fd354276d3ce\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/48c93e4f-93f9-48dc-b8a1-fd354276d3ce/pipeline.log\">pipeline</a>"]},{"id":"6323e949-38d7-4919-9400-1865fb863c2b","name":"RHEL8 - OpenShift 4 - 22","runTime":1251.093795,"created":"2025-08-13T06:41:46.338357","updated":"2025-08-13T06:41:46.338365","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6323e949-38d7-4919-9400-1865fb863c2b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6323e949-38d7-4919-9400-1865fb863c2b/pipeline.log\">pipeline</a>"]},{"id":"80920a04-4a17-4482-ad5a-671787ccbaa6","name":"RHEL8 - OpenShift 4 - 20","status":"complete","outcome":"passed","runTime":1947.373811,"created":"2025-08-12T15:06:38.443461","updated":"2025-08-12T15:06:38.443470","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/80920a04-4a17-4482-ad5a-671787ccbaa6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/80920a04-4a17-4482-ad5a-671787ccbaa6/pipeline.log\">pipeline</a>"]}]} -->