### PR TITLE
Remove 'version' label from Dockerfile.rhel10

### DIFF
--- a/24-minimal/Dockerfile.rhel10
+++ b/24-minimal/Dockerfile.rhel10
@@ -44,7 +44,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858" \
       com.redhat.component="${NAME}-${NODEJS_VERSION}-minimal-container" \
       name="ubi9/$NAME-$NODEJS_VERSION-minimal" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"

--- a/24/Dockerfile.rhel10
+++ b/24/Dockerfile.rhel10
@@ -47,7 +47,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858" \
       com.redhat.component="${NAME}-${NODEJS_VERSION}-container" \
       name="ubi10/$NAME-$NODEJS_VERSION" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \


### PR DESCRIPTION
Remove 'version' label from Dockerfile.rhel10

Konflux build pipeline needs it.
See https://issues.redhat.com/browse/RHELMISC-17288

<!-- testing-farm = {"lock":"false","comment-id":"3279355620","data":[{"id":"28b91433-aa25-4838-b36e-ca83bc5bef0e","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":746.292558,"created":"2025-09-11T08:52:46.349618","updated":"2025-09-11T08:52:46.349623","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/28b91433-aa25-4838-b36e-ca83bc5bef0e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/28b91433-aa25-4838-b36e-ca83bc5bef0e/pipeline.log\">pipeline</a>"]},{"id":"975abad0-2c94-409e-9766-795dfaf529b2","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":451.35953,"created":"2025-09-11T09:04:53.877570","updated":"2025-09-11T09:04:53.877577","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/975abad0-2c94-409e-9766-795dfaf529b2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/975abad0-2c94-409e-9766-795dfaf529b2/pipeline.log\">pipeline</a>"]},{"id":"a417a296-ab79-406e-b8ff-3f48c48e0c63","name":"RHEL9 - 24","status":"complete","outcome":"passed","runTime":1044.109315,"created":"2025-09-11T09:00:45.410355","updated":"2025-09-11T09:00:45.410362","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a417a296-ab79-406e-b8ff-3f48c48e0c63\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a417a296-ab79-406e-b8ff-3f48c48e0c63/pipeline.log\">pipeline</a>"]},{"id":"62e801b9-a2b7-4c0e-a986-3c5a26ca12f5","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1268.343372,"created":"2025-09-11T08:57:20.370169","updated":"2025-09-11T08:57:20.370175","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/62e801b9-a2b7-4c0e-a986-3c5a26ca12f5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/62e801b9-a2b7-4c0e-a986-3c5a26ca12f5/pipeline.log\">pipeline</a>"]},{"id":"a852adca-aac0-4aa1-ac20-0e34c63e8c04","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":1088.702236,"created":"2025-09-11T08:59:44.377532","updated":"2025-09-11T08:59:44.377539","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a852adca-aac0-4aa1-ac20-0e34c63e8c04\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a852adca-aac0-4aa1-ac20-0e34c63e8c04/pipeline.log\">pipeline</a>"]},{"id":"d5a828c7-b5cb-45c6-a590-df112285b6af","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":487.436628,"created":"2025-09-11T09:10:15.704771","updated":"2025-09-11T09:10:15.704779","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d5a828c7-b5cb-45c6-a590-df112285b6af\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d5a828c7-b5cb-45c6-a590-df112285b6af/pipeline.log\">pipeline</a>"]},{"id":"20f4702c-b287-4303-95ed-78bce5bce973","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":603.103713,"created":"2025-09-11T09:11:03.833207","updated":"2025-09-11T09:11:03.833215","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/20f4702c-b287-4303-95ed-78bce5bce973\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/20f4702c-b287-4303-95ed-78bce5bce973/pipeline.log\">pipeline</a>"]},{"id":"a0ff717b-16ba-4a40-8f7e-9ea9e3afb700","name":"RHEL9 - FIPS Enabled - 20-minimal","status":"complete","outcome":"passed","runTime":1501.621285,"created":"2025-09-11T09:01:04.253409","updated":"2025-09-11T09:01:04.253416","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a0ff717b-16ba-4a40-8f7e-9ea9e3afb700\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a0ff717b-16ba-4a40-8f7e-9ea9e3afb700/pipeline.log\">pipeline</a>"]},{"id":"078bc2ad-60e1-4ff2-840a-210c2e05b175","name":"RHEL9 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":1157.674386,"created":"2025-09-11T09:07:44.261160","updated":"2025-09-11T09:07:44.261180","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/078bc2ad-60e1-4ff2-840a-210c2e05b175\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/078bc2ad-60e1-4ff2-840a-210c2e05b175/pipeline.log\">pipeline</a>"]},{"id":"d506815d-628d-4abd-8b47-af4bb4c174aa","name":"RHEL10 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1443.931756,"created":"2025-09-11T09:03:00.387557","updated":"2025-09-11T09:03:00.387564","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d506815d-628d-4abd-8b47-af4bb4c174aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d506815d-628d-4abd-8b47-af4bb4c174aa/pipeline.log\">pipeline</a>"]},{"id":"ba6a1515-4767-41f6-8c53-2d1d1c07e076","name":"Fedora - 24","status":"complete","outcome":"passed","runTime":270.398434,"created":"2025-09-11T09:24:31.030546","updated":"2025-09-11T09:24:31.030552","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ba6a1515-4767-41f6-8c53-2d1d1c07e076\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ba6a1515-4767-41f6-8c53-2d1d1c07e076/pipeline.log\">pipeline</a>"]},{"id":"d5f02b4c-8e53-4fdc-b967-75c19323b894","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1102.038911,"created":"2025-09-11T09:11:14.051997","updated":"2025-09-11T09:11:14.052005","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d5f02b4c-8e53-4fdc-b967-75c19323b894\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d5f02b4c-8e53-4fdc-b967-75c19323b894/pipeline.log\">pipeline</a>"]},{"id":"10c282da-4646-4efb-aa03-001e55bd9245","name":"RHEL8 - 22","status":"complete","outcome":"passed","runTime":1101.634019,"created":"2025-09-11T09:11:19.441174","updated":"2025-09-11T09:11:19.441183","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/10c282da-4646-4efb-aa03-001e55bd9245\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/10c282da-4646-4efb-aa03-001e55bd9245/pipeline.log\">pipeline</a>"]},{"id":"d2f336c1-6f79-4e2d-9a03-2a3ea92162dc","name":"RHEL10 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":736.974805,"created":"2025-09-11T09:20:06.808088","updated":"2025-09-11T09:20:06.808094","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d2f336c1-6f79-4e2d-9a03-2a3ea92162dc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d2f336c1-6f79-4e2d-9a03-2a3ea92162dc/pipeline.log\">pipeline</a>"]},{"id":"43d0a233-460a-44a0-9b89-1a3670ce893b","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1347.445264,"created":"2025-09-11T09:10:43.533336","updated":"2025-09-11T09:10:43.533345","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/43d0a233-460a-44a0-9b89-1a3670ce893b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/43d0a233-460a-44a0-9b89-1a3670ce893b/pipeline.log\">pipeline</a>"]},{"id":"0a95ce3b-4dc9-404c-92a7-88f36b5e3db9","name":"RHEL10 - 22-minimal","status":"complete","outcome":"passed","runTime":854.766327,"created":"2025-09-11T09:20:50.780090","updated":"2025-09-11T09:20:50.780099","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a95ce3b-4dc9-404c-92a7-88f36b5e3db9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a95ce3b-4dc9-404c-92a7-88f36b5e3db9/pipeline.log\">pipeline</a>"]},{"id":"feef29d6-12f5-4431-9111-82c3f97fb260","name":"RHEL9 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":1104.280443,"created":"2025-09-11T09:17:45.377533","updated":"2025-09-11T09:17:45.377540","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/feef29d6-12f5-4431-9111-82c3f97fb260\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/feef29d6-12f5-4431-9111-82c3f97fb260/pipeline.log\">pipeline</a>"]},{"id":"da1cb2bd-bc8a-42d9-8dcf-04b54097026a","name":"Fedora - 24-minimal","status":"complete","outcome":"passed","runTime":237.260809,"created":"2025-09-11T09:35:17.261090","updated":"2025-09-11T09:35:17.261102","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/da1cb2bd-bc8a-42d9-8dcf-04b54097026a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/da1cb2bd-bc8a-42d9-8dcf-04b54097026a/pipeline.log\">pipeline</a>"]},{"id":"24618715-a318-4b1d-b079-25a9bd3a5953","name":"RHEL9 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1544.965958,"created":"2025-09-11T09:13:16.830887","updated":"2025-09-11T09:13:16.830895","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/24618715-a318-4b1d-b079-25a9bd3a5953\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/24618715-a318-4b1d-b079-25a9bd3a5953/pipeline.log\">pipeline</a>"]},{"id":"b960faaa-5e40-413a-bac4-5d16d7218fd1","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":563.054324,"created":"2025-09-11T09:31:35.446424","updated":"2025-09-11T09:31:35.446432","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b960faaa-5e40-413a-bac4-5d16d7218fd1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b960faaa-5e40-413a-bac4-5d16d7218fd1/pipeline.log\">pipeline</a>"]},{"id":"fa6ae675-2a7e-4874-ad5f-1ec27cab3a1b","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":687.742887,"created":"2025-09-11T09:31:53.922876","updated":"2025-09-11T09:31:53.922885","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fa6ae675-2a7e-4874-ad5f-1ec27cab3a1b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fa6ae675-2a7e-4874-ad5f-1ec27cab3a1b/pipeline.log\">pipeline</a>"]},{"id":"ac846546-1b5a-427c-a0d0-4ff3a0fbecfc","name":"RHEL10 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":744.659453,"created":"2025-09-11T09:30:15.113685","updated":"2025-09-11T09:30:15.113692","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ac846546-1b5a-427c-a0d0-4ff3a0fbecfc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ac846546-1b5a-427c-a0d0-4ff3a0fbecfc/pipeline.log\">pipeline</a>"]},{"id":"0849ef9f-556e-45cf-a0f3-a4c2a2c34aeb","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":1001.818872,"created":"2025-09-11T09:27:26.632854","updated":"2025-09-11T09:27:26.632863","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0849ef9f-556e-45cf-a0f3-a4c2a2c34aeb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0849ef9f-556e-45cf-a0f3-a4c2a2c34aeb/pipeline.log\">pipeline</a>"]},{"id":"8fbaa7ba-988b-4182-aed9-7afd75ce8aac","name":"RHEL10 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":962.623121,"created":"2025-09-11T09:29:30.510301","updated":"2025-09-11T09:29:30.510307","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8fbaa7ba-988b-4182-aed9-7afd75ce8aac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8fbaa7ba-988b-4182-aed9-7afd75ce8aac/pipeline.log\">pipeline</a>"]},{"id":"e8ade86c-9f32-4b15-ad9a-e483b92efef8","name":"RHEL8 - 22-minimal","status":"complete","outcome":"passed","runTime":1069.232725,"created":"2025-09-11T09:28:09.996214","updated":"2025-09-11T09:28:09.996223","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8ade86c-9f32-4b15-ad9a-e483b92efef8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8ade86c-9f32-4b15-ad9a-e483b92efef8/pipeline.log\">pipeline</a>"]},{"id":"2917f7ae-5677-4936-82cb-79602d061da6","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":708.255974,"created":"2025-09-11T09:35:37.290661","updated":"2025-09-11T09:35:37.290668","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2917f7ae-5677-4936-82cb-79602d061da6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2917f7ae-5677-4936-82cb-79602d061da6/pipeline.log\">pipeline</a>"]},{"id":"4b50c87d-61a3-4fed-98d1-01bf8d3f02a6","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":622.268656,"created":"2025-09-11T09:38:19.614750","updated":"2025-09-11T09:38:19.614758","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4b50c87d-61a3-4fed-98d1-01bf8d3f02a6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4b50c87d-61a3-4fed-98d1-01bf8d3f02a6/pipeline.log\">pipeline</a>"]},{"id":"2ba0f4f7-680b-40d4-8cf1-06b211850a7d","name":"RHEL10 - 24-minimal","status":"complete","outcome":"passed","runTime":929.209805,"created":"2025-09-11T09:34:30.414015","updated":"2025-09-11T09:34:30.414023","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2ba0f4f7-680b-40d4-8cf1-06b211850a7d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2ba0f4f7-680b-40d4-8cf1-06b211850a7d/pipeline.log\">pipeline</a>"]},{"id":"e83b552d-8d4c-4d17-988a-33afafd8510e","name":"RHEL10 - 24","status":"complete","outcome":"passed","runTime":645.994704,"created":"2025-09-11T09:38:56.411817","updated":"2025-09-11T09:38:56.411830","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e83b552d-8d4c-4d17-988a-33afafd8510e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e83b552d-8d4c-4d17-988a-33afafd8510e/pipeline.log\">pipeline</a>"]},{"id":"26126c7b-5a46-4e87-af34-d98e982e535a","name":"RHEL9 - 24-minimal","status":"complete","outcome":"passed","runTime":953.690108,"created":"2025-09-11T09:38:15.674827","updated":"2025-09-11T09:38:15.674843","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/26126c7b-5a46-4e87-af34-d98e982e535a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/26126c7b-5a46-4e87-af34-d98e982e535a/pipeline.log\">pipeline</a>"]},{"id":"bd8ea2a3-dcd1-4fe9-89a7-8048e7075062","name":"RHEL9 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1686.716804,"created":"2025-09-11T09:26:26.169669","updated":"2025-09-11T09:26:26.169677","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bd8ea2a3-dcd1-4fe9-89a7-8048e7075062\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bd8ea2a3-dcd1-4fe9-89a7-8048e7075062/pipeline.log\">pipeline</a>"]},{"id":"4056d8cb-3f9c-442f-9c8f-b3d772d455e9","name":"RHEL9 - FIPS Enabled - 20","status":"complete","outcome":"passed","runTime":1581.966807,"created":"2025-09-11T09:29:05.793627","updated":"2025-09-11T09:29:05.793635","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4056d8cb-3f9c-442f-9c8f-b3d772d455e9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4056d8cb-3f9c-442f-9c8f-b3d772d455e9/pipeline.log\">pipeline</a>"]},{"id":"c92a79f8-adb2-44e1-a639-765bf52c54b1","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1307.005519,"created":"2025-09-11T09:37:16.905366","updated":"2025-09-11T09:37:16.905376","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c92a79f8-adb2-44e1-a639-765bf52c54b1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c92a79f8-adb2-44e1-a639-765bf52c54b1/pipeline.log\">pipeline</a>"]},{"id":"02f47540-85a3-415d-ac97-15e7225574aa","name":"RHEL9 - 22-minimal","runTime":1274.424593,"created":"2025-09-11T09:39:29.833140","updated":"2025-09-11T09:39:29.833151","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/02f47540-85a3-415d-ac97-15e7225574aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/02f47540-85a3-415d-ac97-15e7225574aa/pipeline.log\">pipeline</a>"]}]} -->