### PR TITLE
On RHEL10. node is not installed

### DIFF
--- a/24-minimal/Dockerfile.rhel10
+++ b/24-minimal/Dockerfile.rhel10
@@ -51,6 +51,9 @@ LABEL summary="$SUMMARY" \
 # nodejs-full-i18n is included for error strings
 RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
+    ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
+    ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
+    ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     microdnf clean all && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*

--- a/24/Dockerfile.rhel10
+++ b/24/Dockerfile.rhel10
@@ -56,9 +56,9 @@ LABEL summary="$SUMMARY" \
 RUN INSTALL_PKGS="make gcc gcc-c++ git openssl-devel nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
     dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    rm /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
-    rm /usr/bin/npm && ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
-    rm /usr/bin/npx && ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
+    ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
+    ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
+    ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
     dnf -y clean all --enablerepo='*'
 


### PR DESCRIPTION
In Konflux pipeline it looks like /usr/bin/node, /usr/bin/npx, /usr/bin/npm does not exist.
And therefore build is failing.

<!-- testing-farm = {"lock":"false","comment-id":"3284883267","data":[{"id":"be90c03f-5e00-4ec6-98eb-95ec1999616f","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":623.380245,"created":"2025-09-12T11:10:09.858906","updated":"2025-09-12T11:10:09.858912","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/be90c03f-5e00-4ec6-98eb-95ec1999616f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/be90c03f-5e00-4ec6-98eb-95ec1999616f/pipeline.log\">pipeline</a>"]},{"id":"b66b88fa-2ad7-40d1-b499-13969ea13eaf","name":"RHEL10 - 24","status":"complete","outcome":"passed","runTime":711.886632,"created":"2025-09-12T11:10:17.237300","updated":"2025-09-12T11:10:17.237329","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b66b88fa-2ad7-40d1-b499-13969ea13eaf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b66b88fa-2ad7-40d1-b499-13969ea13eaf/pipeline.log\">pipeline</a>"]},{"id":"b1cfe4f1-2d2c-4c23-9fc8-2dbb49f99ff4","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":652.60528,"created":"2025-09-12T11:10:44.261244","updated":"2025-09-12T11:10:44.261262","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b1cfe4f1-2d2c-4c23-9fc8-2dbb49f99ff4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b1cfe4f1-2d2c-4c23-9fc8-2dbb49f99ff4/pipeline.log\">pipeline</a>"]},{"id":"4bf04c71-28eb-44b5-a105-e1725e17b713","name":"RHEL10 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":752.170375,"created":"2025-09-12T11:10:10.583709","updated":"2025-09-12T11:10:10.583715","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bf04c71-28eb-44b5-a105-e1725e17b713\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bf04c71-28eb-44b5-a105-e1725e17b713/pipeline.log\">pipeline</a>"]},{"id":"a21b1a29-7f36-4ba9-8f1c-25d45179c049","name":"RHEL10 - 24-minimal","status":"complete","outcome":"passed","runTime":727.418773,"created":"2025-09-12T11:10:17.457435","updated":"2025-09-12T11:10:17.457442","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a21b1a29-7f36-4ba9-8f1c-25d45179c049\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a21b1a29-7f36-4ba9-8f1c-25d45179c049/pipeline.log\">pipeline</a>"]},{"id":"397a32bd-9e96-4540-8066-fa529c666e93","name":"RHEL10 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":736.784525,"created":"2025-09-12T11:10:12.326532","updated":"2025-09-12T11:10:12.326541","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/397a32bd-9e96-4540-8066-fa529c666e93\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/397a32bd-9e96-4540-8066-fa529c666e93/pipeline.log\">pipeline</a>"]},{"id":"a30446d6-ae95-4c9e-a075-2c27524ee890","name":"RHEL10 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1012.95394,"created":"2025-09-12T11:10:11.561696","updated":"2025-09-12T11:10:11.561705","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a30446d6-ae95-4c9e-a075-2c27524ee890\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a30446d6-ae95-4c9e-a075-2c27524ee890/pipeline.log\">pipeline</a>"]},{"id":"76d982bf-6b2e-41ac-b33e-64157416ffe8","name":"Fedora - 24-minimal","status":"complete","outcome":"passed","runTime":344.728874,"created":"2025-09-12T11:22:32.479018","updated":"2025-09-12T11:22:32.479026","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/76d982bf-6b2e-41ac-b33e-64157416ffe8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/76d982bf-6b2e-41ac-b33e-64157416ffe8/pipeline.log\">pipeline</a>"]},{"id":"3898db21-87b3-4abc-96a2-be2b16d11213","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1152.890237,"created":"2025-09-12T11:10:10.066003","updated":"2025-09-12T11:10:10.066008","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3898db21-87b3-4abc-96a2-be2b16d11213\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3898db21-87b3-4abc-96a2-be2b16d11213/pipeline.log\">pipeline</a>"]},{"id":"ca5a36c8-1778-495d-ad54-924b5201b7e0","name":"RHEL10 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1121.482592,"created":"2025-09-12T11:10:11.282628","updated":"2025-09-12T11:10:11.282636","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ca5a36c8-1778-495d-ad54-924b5201b7e0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ca5a36c8-1778-495d-ad54-924b5201b7e0/pipeline.log\">pipeline</a>"]},{"id":"5074ec36-6de5-477a-ae0d-f527008b59c2","name":"RHEL8 - 22","status":"complete","outcome":"passed","runTime":1190.256587,"created":"2025-09-12T11:10:17.971348","updated":"2025-09-12T11:10:17.971356","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5074ec36-6de5-477a-ae0d-f527008b59c2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5074ec36-6de5-477a-ae0d-f527008b59c2/pipeline.log\">pipeline</a>"]},{"id":"19c166ab-17cb-45f0-ad16-8dccb2791470","name":"RHEL9 - 24-minimal","status":"complete","outcome":"passed","runTime":1108.915917,"created":"2025-09-12T11:10:19.893958","updated":"2025-09-12T11:10:19.893967","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/19c166ab-17cb-45f0-ad16-8dccb2791470\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/19c166ab-17cb-45f0-ad16-8dccb2791470/pipeline.log\">pipeline</a>"]},{"id":"56b0f6d5-79e3-4537-b633-8bb5e7324be8","name":"Fedora - 24","status":"complete","outcome":"passed","runTime":329.242424,"created":"2025-09-12T11:24:28.790318","updated":"2025-09-12T11:24:28.790324","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/56b0f6d5-79e3-4537-b633-8bb5e7324be8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/56b0f6d5-79e3-4537-b633-8bb5e7324be8/pipeline.log\">pipeline</a>"]},{"id":"6edfc560-2a7e-497a-b09c-5d87b25ac8bf","name":"RHEL9 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":1118.777549,"created":"2025-09-12T11:10:12.713215","updated":"2025-09-12T11:10:12.713221","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6edfc560-2a7e-497a-b09c-5d87b25ac8bf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6edfc560-2a7e-497a-b09c-5d87b25ac8bf/pipeline.log\">pipeline</a>"]},{"id":"63f15a07-fa8d-4462-98c3-c84fe82f0d63","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":599.445457,"created":"2025-09-12T11:22:17.935986","updated":"2025-09-12T11:22:17.935996","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/63f15a07-fa8d-4462-98c3-c84fe82f0d63\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/63f15a07-fa8d-4462-98c3-c84fe82f0d63/pipeline.log\">pipeline</a>"]},{"id":"0108a6bb-efa0-4b52-ab82-78587b4cbe4d","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":1315.448862,"created":"2025-09-12T11:10:35.053067","updated":"2025-09-12T11:10:35.053073","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0108a6bb-efa0-4b52-ab82-78587b4cbe4d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0108a6bb-efa0-4b52-ab82-78587b4cbe4d/pipeline.log\">pipeline</a>"]},{"id":"1e218c46-0df7-4540-9fd5-ecd16a50a9da","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":696.517735,"created":"2025-09-12T11:22:38.308865","updated":"2025-09-12T11:22:38.308872","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1e218c46-0df7-4540-9fd5-ecd16a50a9da\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1e218c46-0df7-4540-9fd5-ecd16a50a9da/pipeline.log\">pipeline</a>"]},{"id":"3429e50e-0d9e-4100-a1ed-0a98f2915317","name":"RHEL9 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1555.651896,"created":"2025-09-12T11:10:08.401646","updated":"2025-09-12T11:10:08.401652","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3429e50e-0d9e-4100-a1ed-0a98f2915317\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3429e50e-0d9e-4100-a1ed-0a98f2915317/pipeline.log\">pipeline</a>"]},{"id":"63100f5e-6997-445c-b275-be34781a0f54","name":"RHEL9 - FIPS Enabled - 20","status":"complete","outcome":"passed","runTime":1626.499548,"created":"2025-09-12T11:10:11.419924","updated":"2025-09-12T11:10:11.419933","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/63100f5e-6997-445c-b275-be34781a0f54\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/63100f5e-6997-445c-b275-be34781a0f54/pipeline.log\">pipeline</a>"]},{"id":"cd57b2c9-5d9e-48f9-b03d-d467a7ae54d4","name":"RHEL9 - FIPS Enabled - 20-minimal","status":"complete","outcome":"passed","runTime":1563.758504,"created":"2025-09-12T11:10:12.236966","updated":"2025-09-12T11:10:12.236972","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd57b2c9-5d9e-48f9-b03d-d467a7ae54d4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd57b2c9-5d9e-48f9-b03d-d467a7ae54d4/pipeline.log\">pipeline</a>"]},{"id":"e2da0f3d-ab8b-491c-9018-b5adc4d0380d","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":541.619464,"created":"2025-09-12T11:28:57.253358","updated":"2025-09-12T11:28:57.253369","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e2da0f3d-ab8b-491c-9018-b5adc4d0380d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e2da0f3d-ab8b-491c-9018-b5adc4d0380d/pipeline.log\">pipeline</a>"]},{"id":"bdcd703f-a06a-417c-8f24-be61f0c89a47","name":"RHEL9 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1726.763525,"created":"2025-09-12T11:10:08.321961","updated":"2025-09-12T11:10:08.321968","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdcd703f-a06a-417c-8f24-be61f0c89a47\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdcd703f-a06a-417c-8f24-be61f0c89a47/pipeline.log\">pipeline</a>"]},{"id":"616b414b-f682-4c92-9b6d-5ebf3404a4ac","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":528.602055,"created":"2025-09-12T11:30:26.839492","updated":"2025-09-12T11:30:26.839498","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/616b414b-f682-4c92-9b6d-5ebf3404a4ac\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/616b414b-f682-4c92-9b6d-5ebf3404a4ac/pipeline.log\">pipeline</a>"]},{"id":"91bdabb0-5810-4877-9abb-a47c22f7a1ea","name":"RHEL8 - 22-minimal","status":"complete","outcome":"passed","runTime":1043.875313,"created":"2025-09-12T11:23:17.960541","updated":"2025-09-12T11:23:17.960549","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/91bdabb0-5810-4877-9abb-a47c22f7a1ea\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/91bdabb0-5810-4877-9abb-a47c22f7a1ea/pipeline.log\">pipeline</a>"]},{"id":"59405e75-2ace-4b6d-b2f0-5fa86bbe54f8","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":1004.742634,"created":"2025-09-12T11:24:33.677936","updated":"2025-09-12T11:24:33.677944","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/59405e75-2ace-4b6d-b2f0-5fa86bbe54f8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/59405e75-2ace-4b6d-b2f0-5fa86bbe54f8/pipeline.log\">pipeline</a>"]},{"id":"fe168b5f-4484-4c0a-b6d4-b1e4aae060af","name":"RHEL10 - 22-minimal","status":"complete","outcome":"passed","runTime":852.328572,"created":"2025-09-12T11:28:31.230956","updated":"2025-09-12T11:28:31.230963","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe168b5f-4484-4c0a-b6d4-b1e4aae060af\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe168b5f-4484-4c0a-b6d4-b1e4aae060af/pipeline.log\">pipeline</a>"]},{"id":"4a609811-07a4-49d5-8585-9c081de995d8","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1294.023867,"created":"2025-09-12T11:22:37.156289","updated":"2025-09-12T11:22:37.156297","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4a609811-07a4-49d5-8585-9c081de995d8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4a609811-07a4-49d5-8585-9c081de995d8/pipeline.log\">pipeline</a>"]},{"id":"9faf0e5c-95b1-46c5-9a73-b2488cbd221a","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":768.987664,"created":"2025-09-12T11:30:49.060230","updated":"2025-09-12T11:30:49.060236","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9faf0e5c-95b1-46c5-9a73-b2488cbd221a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9faf0e5c-95b1-46c5-9a73-b2488cbd221a/pipeline.log\">pipeline</a>"]},{"id":"ad4a02c3-0ef6-4c90-a0d9-6c95a7261196","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1263.002344,"created":"2025-09-12T11:24:41.736626","updated":"2025-09-12T11:24:41.736632","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad4a02c3-0ef6-4c90-a0d9-6c95a7261196\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad4a02c3-0ef6-4c90-a0d9-6c95a7261196/pipeline.log\">pipeline</a>"]},{"id":"8d9da582-c48a-4d8d-96ed-7f8f5966a631","name":"RHEL9 - 24","status":"complete","outcome":"passed","runTime":963.375182,"created":"2025-09-12T11:30:39.365138","updated":"2025-09-12T11:30:39.365145","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d9da582-c48a-4d8d-96ed-7f8f5966a631\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d9da582-c48a-4d8d-96ed-7f8f5966a631/pipeline.log\">pipeline</a>"]},{"id":"b4fba862-4cef-4804-aeb4-fdf400caeefc","name":"RHEL9 - 22","runTime":1327.481902,"created":"2025-09-12T11:30:36.981597","updated":"2025-09-12T11:30:36.981604","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4fba862-4cef-4804-aeb4-fdf400caeefc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4fba862-4cef-4804-aeb4-fdf400caeefc/pipeline.log\">pipeline</a>"]}]} -->