### PR TITLE
Removing langchain.js from testing suite due to yarn is necessary for installation

### DIFF
--- a/test/run-upstream
+++ b/test/run-upstream
@@ -26,7 +26,6 @@ test_client_faas
 test_client_cloudevents
 test_client_fastify
 test_client_pino
-test_client_langchainjs
 "
 
 TEST_LIST_BINARY="\
@@ -49,8 +48,6 @@ readonly CLOUDEVENTS_REVISION="v${CLOUDEVENTS_REVISION:-$(docker run --rm "${IMA
 readonly CLOUDEVENTS_REPO="https://github.com/cloudevents/sdk-javascript.git"
 readonly FASTIFY_REVISION="v${FASTIFY_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show fastify version)}"
 readonly FASTIFY_REPO="https://github.com/fastify/fastify.git"
-readonly LANGCHAINJS_REVISION="${LANGCHAINJS_REVISION:-$(docker run --rm "${IMAGE_NAME}" -- npm show langchain version)}"
-readonly LANGCHAINJS_REPO="https://github.com/langchain-ai/langchainjs.git"
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from a registry

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -444,11 +444,6 @@ function test_client_cloudevents() {
   test_running_client_js cloudevents
 }
 
-function test_client_langchainjs() {
-  echo "Running langchainjs client test"
-  test_running_client_js langchainjs
-}
-
 function test_client_fastify() {
   if [[ "${VERSION}" == *"minimal"* ]]; then
     VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
## Removing langchain.js from the testing suite.

This PR removes `langchain.js` from the testing suite because the yarn binary isn't available on the base images.

Until we further investigate how to properly include and install the yarn binary on the base images to test the `langchain.js` library, it's better to remove `langchain.js`. Currently, the failing test is a false alarm indication, as `Langchain` itself is not failing.

<!-- testing-farm = {"lock":"false","comment-id":"3546086500","data":[{"id":"668db408-599c-4815-9d66-9c9b906bfcdb","name":"Fedora - UpstreamTests - 22-minimal","status":"complete","outcome":"passed","runTime":407.445181,"created":"2026-01-15T16:21:58.208562","updated":"2026-01-15T16:21:58.208571","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/668db408-599c-4815-9d66-9c9b906bfcdb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/668db408-599c-4815-9d66-9c9b906bfcdb/pipeline.log\">pipeline</a>"]},{"id":"829bdde5-e626-4228-8b2f-890f29894157","name":"Fedora - UpstreamTests - 24-minimal","status":"complete","outcome":"passed","runTime":390.993471,"created":"2026-01-15T16:54:38.317418","updated":"2026-01-15T16:54:38.317424","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/829bdde5-e626-4228-8b2f-890f29894157\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/829bdde5-e626-4228-8b2f-890f29894157/pipeline.log\">pipeline</a>"]},{"id":"00e2bd1a-2b77-48c8-9bf7-0225685380e3","name":"Fedora - UpstreamTests - 20-minimal","status":"complete","outcome":"passed","runTime":468.190202,"created":"2026-01-15T16:21:50.600235","updated":"2026-01-15T16:21:50.600241","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/00e2bd1a-2b77-48c8-9bf7-0225685380e3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/00e2bd1a-2b77-48c8-9bf7-0225685380e3/pipeline.log\">pipeline</a>"]},{"id":"fd47a815-5b36-47e0-9c76-c71efd5ede88","name":"CentOS Stream 10 - UpstreamTests - 22-minimal","status":"complete","outcome":"passed","runTime":470.655071,"created":"2026-01-15T16:21:53.075506","updated":"2026-01-15T16:21:53.075515","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fd47a815-5b36-47e0-9c76-c71efd5ede88\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fd47a815-5b36-47e0-9c76-c71efd5ede88/pipeline.log\">pipeline</a>"]},{"id":"f3b8f36d-c75b-4c0c-a5cb-d37518a48e38","name":"CentOS Stream 10 - UpstreamTests - 24-minimal","status":"complete","outcome":"passed","runTime":448.523939,"created":"2026-01-15T16:21:52.836414","updated":"2026-01-15T16:21:52.836421","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f3b8f36d-c75b-4c0c-a5cb-d37518a48e38\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f3b8f36d-c75b-4c0c-a5cb-d37518a48e38/pipeline.log\">pipeline</a>"]},{"id":"c0fdde39-2e21-4703-ad03-b4cb2e15c4d4","name":"RHEL8 - UpstreamTests - 20-minimal","status":"complete","outcome":"passed","runTime":1621.793249,"created":"2026-01-15T16:46:29.190629","updated":"2026-01-15T16:46:29.190636","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0fdde39-2e21-4703-ad03-b4cb2e15c4d4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0fdde39-2e21-4703-ad03-b4cb2e15c4d4/pipeline.log\">pipeline</a>"]},{"id":"2c987c0b-a482-4411-89cb-c101a4fefa3d","name":"RHEL10 - UpstreamTests - 22-minimal","status":"complete","outcome":"passed","runTime":1749.400842,"created":"2026-01-15T16:21:55.827531","updated":"2026-01-15T16:21:55.827539","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2c987c0b-a482-4411-89cb-c101a4fefa3d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2c987c0b-a482-4411-89cb-c101a4fefa3d/pipeline.log\">pipeline</a>"]},{"id":"192f3b76-09e7-4589-ac87-435d0bacd3d2","name":"RHEL9 - UpstreamTests - 22-minimal","status":"complete","outcome":"passed","runTime":1967.83728,"created":"2026-01-15T16:21:52.230506","updated":"2026-01-15T16:21:52.230512","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/192f3b76-09e7-4589-ac87-435d0bacd3d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/192f3b76-09e7-4589-ac87-435d0bacd3d2/pipeline.log\">pipeline</a>"]},{"id":"9d22774a-12c1-41a8-949f-17d0a0081d30","name":"Fedora - UpstreamTests - 22","status":"complete","outcome":"error","runTime":1360.878629,"created":"2026-01-15T16:21:52.566430","updated":"2026-01-15T16:21:52.566438","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9d22774a-12c1-41a8-949f-17d0a0081d30\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9d22774a-12c1-41a8-949f-17d0a0081d30/pipeline.log\">pipeline</a>"]},{"id":"614144ce-0dcc-46ea-932b-15c142c203f9","name":"RHEL9 - UpstreamTests - 20-minimal","status":"complete","outcome":"passed","runTime":2067.446044,"created":"2026-01-15T16:21:50.713615","updated":"2026-01-15T16:21:50.713622","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/614144ce-0dcc-46ea-932b-15c142c203f9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/614144ce-0dcc-46ea-932b-15c142c203f9/pipeline.log\">pipeline</a>"]},{"id":"f9197394-81b4-400b-b187-d91d08a9699c","name":"Fedora - UpstreamTests - 24","status":"complete","outcome":"error","runTime":1240.290765,"created":"2026-01-15T16:21:52.368236","updated":"2026-01-15T16:21:52.368245","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f9197394-81b4-400b-b187-d91d08a9699c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f9197394-81b4-400b-b187-d91d08a9699c/pipeline.log\">pipeline</a>"]},{"id":"9f13499c-f938-4855-bf69-251ca6075fb5","name":"RHEL10 - UpstreamTests - 24-minimal","status":"complete","outcome":"passed","runTime":1786.025807,"created":"2026-01-15T16:50:32.604692","updated":"2026-01-15T16:50:32.604700","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f13499c-f938-4855-bf69-251ca6075fb5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f13499c-f938-4855-bf69-251ca6075fb5/pipeline.log\">pipeline</a>"]},{"id":"a3614137-1d6e-48c3-85f5-4dc736ca0eea","name":"CentOS Stream 9 - UpstreamTests - 24","status":"complete","outcome":"error","runTime":1434.785992,"created":"2026-01-15T16:56:36.696612","updated":"2026-01-15T16:56:36.696619","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a3614137-1d6e-48c3-85f5-4dc736ca0eea\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a3614137-1d6e-48c3-85f5-4dc736ca0eea/pipeline.log\">pipeline</a>"]},{"id":"de47ea16-bd00-45a7-85bb-77e80b0ce347","name":"CentOS Stream 9 - UpstreamTests - 20","status":"complete","outcome":"error","runTime":1399.824204,"created":"2026-01-15T16:56:52.973937","updated":"2026-01-15T16:56:52.973944","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/de47ea16-bd00-45a7-85bb-77e80b0ce347\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/de47ea16-bd00-45a7-85bb-77e80b0ce347/pipeline.log\">pipeline</a>"]},{"id":"ecb386e1-9ef2-4e14-b8b5-1eb3dca7499e","name":"RHEL8 - UpstreamTests - 22-minimal","status":"complete","outcome":"passed","runTime":1823.562835,"created":"2026-01-15T16:21:57.284795","updated":"2026-01-15T16:21:57.284801","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ecb386e1-9ef2-4e14-b8b5-1eb3dca7499e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ecb386e1-9ef2-4e14-b8b5-1eb3dca7499e/pipeline.log\">pipeline</a>"]},{"id":"00856bc0-5b2d-4f72-9697-5aa22dc195ef","name":"CentOS Stream 10 - UpstreamTests - 24","status":"complete","outcome":"error","runTime":1326.937266,"created":"2026-01-15T16:21:53.786519","updated":"2026-01-15T16:21:53.786526","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/00856bc0-5b2d-4f72-9697-5aa22dc195ef\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/00856bc0-5b2d-4f72-9697-5aa22dc195ef/pipeline.log\">pipeline</a>"]},{"id":"0049ff1b-0ad2-4ba0-b7ae-39553e72375a","name":"CentOS Stream 9 - UpstreamTests - 24-minimal","status":"complete","outcome":"passed","runTime":609.926767,"created":"2026-01-15T16:30:16.459734","updated":"2026-01-15T16:30:16.459739","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0049ff1b-0ad2-4ba0-b7ae-39553e72375a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0049ff1b-0ad2-4ba0-b7ae-39553e72375a/pipeline.log\">pipeline</a>"]},{"id":"c934e325-50eb-4d65-9f91-4021b3c71aeb","name":"CentOS Stream 9 - UpstreamTests - 20-minimal","status":"complete","outcome":"passed","runTime":584.889957,"created":"2026-01-15T16:21:58.321918","updated":"2026-01-15T16:21:58.321925","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c934e325-50eb-4d65-9f91-4021b3c71aeb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c934e325-50eb-4d65-9f91-4021b3c71aeb/pipeline.log\">pipeline</a>"]},{"id":"22392bc0-dc54-4e8e-8147-7c8f168b1896","name":"RHEL10 - UpstreamTests - 22","status":"complete","outcome":"error","runTime":2825.906323,"created":"2026-01-15T16:21:51.594038","updated":"2026-01-15T16:21:51.594045","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/22392bc0-dc54-4e8e-8147-7c8f168b1896\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/22392bc0-dc54-4e8e-8147-7c8f168b1896/pipeline.log\">pipeline</a>"]},{"id":"ff5f94ea-ee80-4697-9625-4008335009a5","name":"RHEL8 - UpstreamTests - 22","status":"complete","outcome":"error","runTime":2964.008986,"created":"2026-01-15T16:21:50.679100","updated":"2026-01-15T16:21:50.679131","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ff5f94ea-ee80-4697-9625-4008335009a5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ff5f94ea-ee80-4697-9625-4008335009a5/pipeline.log\">pipeline</a>"]},{"id":"d344be42-4485-4a80-8f78-6519d9114e04","name":"RHEL10 - UpstreamTests - 24","status":"complete","outcome":"error","runTime":2598.752113,"created":"2026-01-15T16:30:39.720986","updated":"2026-01-15T16:30:39.720997","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d344be42-4485-4a80-8f78-6519d9114e04\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d344be42-4485-4a80-8f78-6519d9114e04/pipeline.log\">pipeline</a>"]},{"id":"441353fa-82f0-4f07-b3aa-556e51fe6278","name":"Fedora - UpstreamTests - 20","status":"complete","outcome":"error","runTime":1572.747116,"created":"2026-01-15T16:21:57.889255","updated":"2026-01-15T16:21:57.889263","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/441353fa-82f0-4f07-b3aa-556e51fe6278\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/441353fa-82f0-4f07-b3aa-556e51fe6278/pipeline.log\">pipeline</a>"]},{"id":"dc0b3652-050c-4947-8bbd-ab332a3e0d2d","name":"RHEL8 - UpstreamTests - 20","status":"complete","outcome":"error","runTime":2716.300597,"created":"2026-01-15T16:52:24.322251","updated":"2026-01-15T16:52:24.322258","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dc0b3652-050c-4947-8bbd-ab332a3e0d2d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dc0b3652-050c-4947-8bbd-ab332a3e0d2d/pipeline.log\">pipeline</a>"]},{"id":"7ff3a870-2e88-48be-93be-4cc627d9a8b9","name":"RHEL9 - UpstreamTests - 24-minimal","status":"complete","outcome":"passed","runTime":1022.23007,"created":"2025-11-18T08:23:06.993260","updated":"2025-11-18T08:23:06.993266","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ff3a870-2e88-48be-93be-4cc627d9a8b9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7ff3a870-2e88-48be-93be-4cc627d9a8b9/pipeline.log\">pipeline</a>"]},{"id":"469d9975-cf8f-4c9d-8717-c928a8498e2e","name":"RHEL9 - UpstreamTests - 24","status":"complete","outcome":"error","runTime":3193.703338,"created":"2026-01-15T16:21:57.188490","updated":"2026-01-15T16:21:57.188497","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/469d9975-cf8f-4c9d-8717-c928a8498e2e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/469d9975-cf8f-4c9d-8717-c928a8498e2e/pipeline.log\">pipeline</a>"]},{"id":"d4953279-ae3e-4fdb-80d7-49ba5108b604","name":"RHEL9 - UpstreamTests - 20","status":"complete","outcome":"error","runTime":2898.571692,"created":"2026-01-15T16:22:03.411493","updated":"2026-01-15T16:22:03.411500","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4953279-ae3e-4fdb-80d7-49ba5108b604\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4953279-ae3e-4fdb-80d7-49ba5108b604/pipeline.log\">pipeline</a>"]},{"id":"256f9669-d984-44c8-aca1-8864272e2fa1","name":"RHEL9 - UpstreamTests - 22","status":"complete","outcome":"error","runTime":3201.167476,"created":"2026-01-15T16:21:52.409283","updated":"2026-01-15T16:21:52.409291","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/256f9669-d984-44c8-aca1-8864272e2fa1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/256f9669-d984-44c8-aca1-8864272e2fa1/pipeline.log\">pipeline</a>"]},{"id":"7fb3d591-7bc8-421b-918b-d5d22d6adba4","name":"RHEL10 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":1989.86123,"created":"2026-01-15T16:22:25.522474","updated":"2026-01-15T16:22:25.522482","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7fb3d591-7bc8-421b-918b-d5d22d6adba4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7fb3d591-7bc8-421b-918b-d5d22d6adba4/pipeline.log\">pipeline</a>"]},{"id":"4ed54da2-a798-46e0-9d78-388fc0c09d0a","name":"RHEL9 - FIPS Enabled - 20-minimal","status":"complete","outcome":"passed","runTime":2305.198137,"created":"2026-01-15T16:30:22.751867","updated":"2026-01-15T16:30:22.751875","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ed54da2-a798-46e0-9d78-388fc0c09d0a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4ed54da2-a798-46e0-9d78-388fc0c09d0a/pipeline.log\">pipeline</a>"]},{"id":"dfbe556e-9e16-4811-8791-e0dcb810c033","name":"RHEL9 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":2347.037415,"created":"2026-01-15T16:30:26.326098","updated":"2026-01-15T16:30:26.326107","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dfbe556e-9e16-4811-8791-e0dcb810c033\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dfbe556e-9e16-4811-8791-e0dcb810c033/pipeline.log\">pipeline</a>"]},{"id":"a7112db9-4bc3-498e-936f-42f9d1763a46","name":"RHEL9 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":2371.332988,"created":"2026-01-15T16:32:21.503234","updated":"2026-01-15T16:32:21.503243","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7112db9-4bc3-498e-936f-42f9d1763a46\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7112db9-4bc3-498e-936f-42f9d1763a46/pipeline.log\">pipeline</a>"]},{"id":"51cd7b9b-8087-4cf9-beda-b669c8181503","name":"RHEL10 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1869.563856,"created":"2026-01-15T16:42:41.483698","updated":"2026-01-15T16:42:41.483728","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/51cd7b9b-8087-4cf9-beda-b669c8181503\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/51cd7b9b-8087-4cf9-beda-b669c8181503/pipeline.log\">pipeline</a>"]},{"id":"9f3722bf-81d3-4d21-b54d-e5ccaa976f96","name":"CentOS Stream 10 - UpstreamTests - 22","status":"complete","outcome":"error","runTime":1246.792753,"created":"2026-01-15T16:56:24.848237","updated":"2026-01-15T16:56:24.848245","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9f3722bf-81d3-4d21-b54d-e5ccaa976f96\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9f3722bf-81d3-4d21-b54d-e5ccaa976f96/pipeline.log\">pipeline</a>"]},{"id":"18c0fdcd-3d93-4e17-abaf-5111d46470da","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":521.138975,"created":"2026-01-15T17:11:02.565025","updated":"2026-01-15T17:11:02.565031","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/18c0fdcd-3d93-4e17-abaf-5111d46470da\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/18c0fdcd-3d93-4e17-abaf-5111d46470da/pipeline.log\">pipeline</a>"]},{"id":"ff924449-939e-4c1a-bb36-f270d5fc8c6d","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":720.819518,"created":"2026-01-15T17:10:56.910231","updated":"2026-01-15T17:10:56.910239","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ff924449-939e-4c1a-bb36-f270d5fc8c6d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ff924449-939e-4c1a-bb36-f270d5fc8c6d/pipeline.log\">pipeline</a>"]},{"id":"b2bc8475-bcde-4b72-b978-86d82598b6a4","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":578.72306,"created":"2026-01-15T17:16:31.765214","updated":"2026-01-15T17:16:31.765220","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b2bc8475-bcde-4b72-b978-86d82598b6a4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b2bc8475-bcde-4b72-b978-86d82598b6a4/pipeline.log\">pipeline</a>"]},{"id":"86fd1838-6ebd-4e8b-8c66-d408c94b3846","name":"RHEL10 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":2459.045896,"created":"2026-01-15T16:44:29.654845","updated":"2026-01-15T16:44:29.654853","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/86fd1838-6ebd-4e8b-8c66-d408c94b3846\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/86fd1838-6ebd-4e8b-8c66-d408c94b3846/pipeline.log\">pipeline</a>"]},{"id":"7afe87c5-8e8e-4b0d-912b-b2a1fadb3f10","name":"RHEL9 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":2427.49439,"created":"2026-01-15T16:46:42.298576","updated":"2026-01-15T16:46:42.298582","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7afe87c5-8e8e-4b0d-912b-b2a1fadb3f10\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7afe87c5-8e8e-4b0d-912b-b2a1fadb3f10/pipeline.log\">pipeline</a>"]},{"id":"57a5d37e-6e57-4a9e-b319-dbf90c980867","name":"RHEL10 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":1883.43835,"created":"2026-01-15T16:58:40.630195","updated":"2026-01-15T16:58:40.630205","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/57a5d37e-6e57-4a9e-b319-dbf90c980867\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/57a5d37e-6e57-4a9e-b319-dbf90c980867/pipeline.log\">pipeline</a>"]},{"id":"55aba4a2-0449-4950-b3c6-69007075a0fd","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":555.971587,"created":"2026-01-15T17:26:59.490334","updated":"2026-01-15T17:26:59.490340","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/55aba4a2-0449-4950-b3c6-69007075a0fd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/55aba4a2-0449-4950-b3c6-69007075a0fd/pipeline.log\">pipeline</a>"]},{"id":"b493c780-fcdb-4edd-a664-f0c124b549bf","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":660.616477,"created":"2026-01-15T17:26:50.303721","updated":"2026-01-15T17:26:50.303727","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b493c780-fcdb-4edd-a664-f0c124b549bf\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b493c780-fcdb-4edd-a664-f0c124b549bf/pipeline.log\">pipeline</a>"]},{"id":"c5f971fd-3270-481d-822c-3e6b74a17c05","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":712.518098,"created":"2026-01-15T17:29:17.127897","updated":"2026-01-15T17:29:17.127905","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c5f971fd-3270-481d-822c-3e6b74a17c05\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c5f971fd-3270-481d-822c-3e6b74a17c05/pipeline.log\">pipeline</a>"]},{"id":"05c32134-6412-406d-b0c6-de1b27ee0330","name":"RHEL10 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":1742.425578,"created":"2026-01-15T17:12:29.080648","updated":"2026-01-15T17:12:29.080654","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/05c32134-6412-406d-b0c6-de1b27ee0330\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/05c32134-6412-406d-b0c6-de1b27ee0330/pipeline.log\">pipeline</a>"]},{"id":"8e757d54-bcc5-41ea-bfbb-0b871433a6ab","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":1829.897894,"created":"2026-01-15T17:12:56.271471","updated":"2026-01-15T17:12:56.271476","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e757d54-bcc5-41ea-bfbb-0b871433a6ab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e757d54-bcc5-41ea-bfbb-0b871433a6ab/pipeline.log\">pipeline</a>"]},{"id":"511ca4b3-cc1c-4933-a97d-b1fe0a8ad186","name":"CentOS Stream 9 - 24","status":"complete","outcome":"passed","runTime":820.487975,"created":"2026-01-15T17:31:13.895205","updated":"2026-01-15T17:31:13.895210","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/511ca4b3-cc1c-4933-a97d-b1fe0a8ad186\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/511ca4b3-cc1c-4933-a97d-b1fe0a8ad186/pipeline.log\">pipeline</a>"]},{"id":"c0601524-b61b-469b-b888-c6975f31a9e3","name":"RHEL9 - FIPS Enabled - 20","status":"complete","outcome":"passed","runTime":2518.572457,"created":"2026-01-15T17:03:23.300043","updated":"2026-01-15T17:03:23.300050","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0601524-b61b-469b-b888-c6975f31a9e3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0601524-b61b-469b-b888-c6975f31a9e3/pipeline.log\">pipeline</a>"]},{"id":"cdaeca17-5a1c-4bee-8ca8-1cbed687911a","name":"RHEL9 - Unsubscribed host - 20-minimal","status":"complete","outcome":"passed","runTime":1909.358929,"created":"2026-01-15T17:15:04.172044","updated":"2026-01-15T17:15:04.172050","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cdaeca17-5a1c-4bee-8ca8-1cbed687911a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cdaeca17-5a1c-4bee-8ca8-1cbed687911a/pipeline.log\">pipeline</a>"]},{"id":"27a23830-1c37-46e6-ad2d-9d8d7fe3e788","name":"RHEL9 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":2349.524654,"created":"2026-01-15T17:10:32.859284","updated":"2026-01-15T17:10:32.859291","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/27a23830-1c37-46e6-ad2d-9d8d7fe3e788\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/27a23830-1c37-46e6-ad2d-9d8d7fe3e788/pipeline.log\">pipeline</a>"]},{"id":"76ab576c-a55c-4456-803e-344041be83c8","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":2198.436469,"created":"2026-01-15T17:12:46.547899","updated":"2026-01-15T17:12:46.547910","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/76ab576c-a55c-4456-803e-344041be83c8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/76ab576c-a55c-4456-803e-344041be83c8/pipeline.log\">pipeline</a>"]},{"id":"ffa84605-13bb-42b8-9715-3e74f0dd0033","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":634.75464,"created":"2026-01-15T17:39:17.977542","updated":"2026-01-15T17:39:17.977550","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ffa84605-13bb-42b8-9715-3e74f0dd0033\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ffa84605-13bb-42b8-9715-3e74f0dd0033/pipeline.log\">pipeline</a>"]},{"id":"f148f1fb-75de-4910-829f-314d5fc3799c","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":2141.123777,"created":"2026-01-15T17:16:46.555759","updated":"2026-01-15T17:16:46.555765","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f148f1fb-75de-4910-829f-314d5fc3799c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f148f1fb-75de-4910-829f-314d5fc3799c/pipeline.log\">pipeline</a>"]},{"id":"c88d6266-9ff7-42ae-855d-47b54b245675","name":"CentOS Stream 10 - 24-minimal","status":"complete","outcome":"passed","runTime":667.614129,"created":"2026-01-15T17:43:04.553960","updated":"2026-01-15T17:43:04.553967","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c88d6266-9ff7-42ae-855d-47b54b245675\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c88d6266-9ff7-42ae-855d-47b54b245675/pipeline.log\">pipeline</a>"]},{"id":"f9354f7f-212d-4203-a1f8-ad2642483faf","name":"Fedora - 24","status":"complete","outcome":"passed","runTime":645.805542,"created":"2026-01-15T17:45:47.220659","updated":"2026-01-15T17:45:47.220666","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f9354f7f-212d-4203-a1f8-ad2642483faf\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f9354f7f-212d-4203-a1f8-ad2642483faf/pipeline.log\">pipeline</a>"]},{"id":"89d31e8c-58ab-4560-826b-1dcbe5779828","name":"RHEL10 - 24-minimal","status":"complete","outcome":"passed","runTime":2281.406221,"created":"2026-01-15T17:21:10.684705","updated":"2026-01-15T17:21:10.684713","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/89d31e8c-58ab-4560-826b-1dcbe5779828\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/89d31e8c-58ab-4560-826b-1dcbe5779828/pipeline.log\">pipeline</a>"]},{"id":"1a43d10c-bc35-43ef-8dcb-577416a475ed","name":"RHEL10 - 22-minimal","status":"complete","outcome":"passed","runTime":2177.75781,"created":"2026-01-15T17:23:30.767169","updated":"2026-01-15T17:23:30.767176","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1a43d10c-bc35-43ef-8dcb-577416a475ed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1a43d10c-bc35-43ef-8dcb-577416a475ed/pipeline.log\">pipeline</a>"]},{"id":"77549718-cee4-48d2-ae9e-804fb70f28f2","name":"RHEL9 - 24-minimal","status":"complete","outcome":"passed","runTime":2786.242702,"created":"2026-01-15T17:15:01.504308","updated":"2026-01-15T17:15:01.504314","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/77549718-cee4-48d2-ae9e-804fb70f28f2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/77549718-cee4-48d2-ae9e-804fb70f28f2/pipeline.log\">pipeline</a>"]},{"id":"1c3b4110-d2e8-43e0-8046-b7a5d5899277","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":2527.934206,"created":"2026-01-15T17:19:11.000861","updated":"2026-01-15T17:19:11.000867","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1c3b4110-d2e8-43e0-8046-b7a5d5899277\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1c3b4110-d2e8-43e0-8046-b7a5d5899277/pipeline.log\">pipeline</a>"]},{"id":"2c2e4d1d-2a47-4670-86d5-5a220d341781","name":"Fedora - 24-minimal","status":"complete","outcome":"passed","runTime":507.785723,"created":"2026-01-15T17:53:21.564887","updated":"2026-01-15T17:53:21.564893","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2c2e4d1d-2a47-4670-86d5-5a220d341781\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2c2e4d1d-2a47-4670-86d5-5a220d341781/pipeline.log\">pipeline</a>"]},{"id":"47169149-2c78-49a8-beb5-eab2d1a8a5c9","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":638.515681,"created":"2026-01-15T17:51:16.734940","updated":"2026-01-15T17:51:16.734946","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/47169149-2c78-49a8-beb5-eab2d1a8a5c9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/47169149-2c78-49a8-beb5-eab2d1a8a5c9/pipeline.log\">pipeline</a>"]},{"id":"4c119eb7-d814-47ec-9050-75b872fe3bd9","name":"RHEL9 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":2601.903749,"created":"2026-01-15T17:21:03.470582","updated":"2026-01-15T17:21:03.470588","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4c119eb7-d814-47ec-9050-75b872fe3bd9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4c119eb7-d814-47ec-9050-75b872fe3bd9/pipeline.log\">pipeline</a>"]},{"id":"beda4a52-169b-4391-a233-21546fada5e9","name":"RHEL9 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":2629.839719,"created":"2026-01-15T17:21:30.436469","updated":"2026-01-15T17:21:30.436477","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/beda4a52-169b-4391-a233-21546fada5e9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/beda4a52-169b-4391-a233-21546fada5e9/pipeline.log\">pipeline</a>"]},{"id":"4377c792-cfc3-489f-a445-b950c461f677","name":"RHEL10 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":1882.122277,"created":"2026-01-15T17:37:30.021040","updated":"2026-01-15T17:37:30.021046","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4377c792-cfc3-489f-a445-b950c461f677\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4377c792-cfc3-489f-a445-b950c461f677/pipeline.log\">pipeline</a>"]},{"id":"471e8c89-3dac-49c0-95c2-350a53dc391e","name":"CentOS Stream 10 - 24","status":"complete","outcome":"passed","runTime":752.344404,"created":"2026-01-15T17:55:39.292662","updated":"2026-01-15T17:55:39.292668","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/471e8c89-3dac-49c0-95c2-350a53dc391e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/471e8c89-3dac-49c0-95c2-350a53dc391e/pipeline.log\">pipeline</a>"]},{"id":"8d31e0cf-2acb-40e2-82cd-18d497c3220f","name":"RHEL10 - 24","status":"complete","outcome":"passed","runTime":1878.800959,"created":"2026-01-15T17:39:00.238547","updated":"2026-01-15T17:39:00.238555","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d31e0cf-2acb-40e2-82cd-18d497c3220f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d31e0cf-2acb-40e2-82cd-18d497c3220f/pipeline.log\">pipeline</a>"]},{"id":"652241bc-b03c-4546-a66f-629df5b70de5","name":"CentOS Stream 9 - 24-minimal","status":"complete","outcome":"passed","runTime":756.838962,"created":"2026-01-15T17:59:44.343017","updated":"2026-01-15T17:59:44.343026","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/652241bc-b03c-4546-a66f-629df5b70de5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/652241bc-b03c-4546-a66f-629df5b70de5/pipeline.log\">pipeline</a>"]},{"id":"c33ba849-195a-4d76-b9b6-f93ed8899517","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1993.484674,"created":"2026-01-15T17:41:44.661358","updated":"2026-01-15T17:41:44.661366","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c33ba849-195a-4d76-b9b6-f93ed8899517\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c33ba849-195a-4d76-b9b6-f93ed8899517/pipeline.log\">pipeline</a>"]},{"id":"c06a60f6-2e80-44a6-89dd-93cac494fb1b","name":"RHEL10 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":1819.908212,"created":"2026-01-15T17:47:33.595674","updated":"2026-01-15T17:47:33.595680","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c06a60f6-2e80-44a6-89dd-93cac494fb1b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c06a60f6-2e80-44a6-89dd-93cac494fb1b/pipeline.log\">pipeline</a>"]},{"id":"8750b9cc-283a-4387-b327-164384be9882","name":"RHEL10 - Unsubscribed host - 22-minimal","status":"complete","outcome":"passed","runTime":1635.852016,"created":"2026-01-15T17:51:42.242275","updated":"2026-01-15T17:51:42.242281","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8750b9cc-283a-4387-b327-164384be9882\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8750b9cc-283a-4387-b327-164384be9882/pipeline.log\">pipeline</a>"]},{"id":"078fdc7a-bce5-4ac3-9d19-4de6a8a69dfc","name":"RHEL9 - Unsubscribed host - 22-minimal","status":"complete","outcome":"passed","runTime":2009.107898,"created":"2026-01-15T17:45:30.571918","updated":"2026-01-15T17:45:30.571926","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/078fdc7a-bce5-4ac3-9d19-4de6a8a69dfc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/078fdc7a-bce5-4ac3-9d19-4de6a8a69dfc/pipeline.log\">pipeline</a>"]},{"id":"ad3dfc39-8363-40d3-8747-1134c11b3049","name":"RHEL9 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":1894.763643,"created":"2026-01-15T17:51:06.072672","updated":"2026-01-15T17:51:06.072678","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad3dfc39-8363-40d3-8747-1134c11b3049\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad3dfc39-8363-40d3-8747-1134c11b3049/pipeline.log\">pipeline</a>"]},{"id":"33be05b8-ff4f-4c20-ba85-9fc892028e02","name":"RHEL9 - Unsubscribed host - 20","status":"complete","outcome":"passed","runTime":2306.750947,"created":"2026-01-15T17:45:46.537095","updated":"2026-01-15T17:45:46.537102","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/33be05b8-ff4f-4c20-ba85-9fc892028e02\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/33be05b8-ff4f-4c20-ba85-9fc892028e02/pipeline.log\">pipeline</a>"]},{"id":"1834fb6b-65b9-40b3-af0b-6d2a27f349d2","name":"RHEL8 - 22-minimal","status":"complete","outcome":"passed","runTime":1803.961834,"created":"2026-01-15T17:58:12.093177","updated":"2026-01-15T17:58:12.093183","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1834fb6b-65b9-40b3-af0b-6d2a27f349d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1834fb6b-65b9-40b3-af0b-6d2a27f349d2/pipeline.log\">pipeline</a>"]},{"id":"17fb83e7-9b87-451c-a9d6-35a89a5b78c7","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":2178.002159,"created":"2026-01-15T17:53:19.297471","updated":"2026-01-15T17:53:19.297479","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/17fb83e7-9b87-451c-a9d6-35a89a5b78c7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/17fb83e7-9b87-451c-a9d6-35a89a5b78c7/pipeline.log\">pipeline</a>"]},{"id":"13bef900-2aab-4b67-9ab1-209030744448","name":"RHEL8 - 22","runTime":1843.677356,"created":"2026-01-15T18:02:17.604664","updated":"2026-01-15T18:02:17.604671","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/13bef900-2aab-4b67-9ab1-209030744448\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/13bef900-2aab-4b67-9ab1-209030744448/pipeline.log\">pipeline</a>"]}]} -->