### PR TITLE
Remove version label for all RHEL10 dockerfiles

### DIFF
--- a/22-minimal/Dockerfile.rhel10
+++ b/22-minimal/Dockerfile.rhel10
@@ -44,7 +44,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858" \
       com.redhat.component="${NAME}-${NODEJS_VERSION}-minimal-container" \
       name="ubi9/$NAME-$NODEJS_VERSION-minimal" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"

--- a/22/Dockerfile.rhel10
+++ b/22/Dockerfile.rhel10
@@ -47,7 +47,6 @@ LABEL summary="$SUMMARY" \
       com.redhat.dev-mode.port="DEBUG_PORT:5858" \
       com.redhat.component="${NAME}-${NODEJS_VERSION}-container" \
       name="ubi10/$NAME-$NODEJS_VERSION" \
-      version="1" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \


### PR DESCRIPTION
See ticket: https://issues.redhat.com/browse/RHELMISC-22529

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- testing-farm = {"lock":"false","comment-id":"3631444105","data":[{"id":"3fea7135-8aad-488f-9ad3-000d72c73275","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":701.38086,"created":"2025-12-09T10:08:18.819440","updated":"2025-12-09T10:08:18.819446","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3fea7135-8aad-488f-9ad3-000d72c73275\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3fea7135-8aad-488f-9ad3-000d72c73275/pipeline.log\">pipeline</a>"]},{"id":"3e0dd191-415d-4aad-bb34-19c69a9dc11b","name":"RHEL10 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1026.349813,"created":"2025-12-09T10:05:25.802378","updated":"2025-12-09T10:05:25.802386","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3e0dd191-415d-4aad-bb34-19c69a9dc11b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3e0dd191-415d-4aad-bb34-19c69a9dc11b/pipeline.log\">pipeline</a>"]},{"id":"28916559-d4f0-48b6-81da-0c3388b243b5","name":"RHEL10 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":1045.025191,"created":"2025-12-09T10:05:26.188230","updated":"2025-12-09T10:05:26.188237","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/28916559-d4f0-48b6-81da-0c3388b243b5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/28916559-d4f0-48b6-81da-0c3388b243b5/pipeline.log\">pipeline</a>"]},{"id":"33a5ceb7-7259-4bc2-b88c-53481c0ea431","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":1050.622712,"created":"2025-12-09T10:06:47.679075","updated":"2025-12-09T10:06:47.679084","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/33a5ceb7-7259-4bc2-b88c-53481c0ea431\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/33a5ceb7-7259-4bc2-b88c-53481c0ea431/pipeline.log\">pipeline</a>"]},{"id":"e100a5d6-070b-4ff2-8047-ec6cab0f9309","name":"RHEL10 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":1157.222892,"created":"2025-12-09T10:05:24.838019","updated":"2025-12-09T10:05:24.838026","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e100a5d6-070b-4ff2-8047-ec6cab0f9309\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e100a5d6-070b-4ff2-8047-ec6cab0f9309/pipeline.log\">pipeline</a>"]},{"id":"21cde3b0-eca1-4278-9c21-68d828b65d5c","name":"RHEL10 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1141.420217,"created":"2025-12-09T10:05:22.922472","updated":"2025-12-09T10:05:22.922479","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/21cde3b0-eca1-4278-9c21-68d828b65d5c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/21cde3b0-eca1-4278-9c21-68d828b65d5c/pipeline.log\">pipeline</a>"]},{"id":"ad7e3979-4a23-418e-aadd-12a3213ed1bf","name":"CentOS Stream 9 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":979.78419,"created":"2025-12-09T10:08:32.299912","updated":"2025-12-09T10:08:32.299919","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ad7e3979-4a23-418e-aadd-12a3213ed1bf\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ad7e3979-4a23-418e-aadd-12a3213ed1bf/pipeline.log\">pipeline</a>"]},{"id":"f2ab4105-5176-4142-ac6e-dbac1ad81d3a","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1312.116072,"created":"2025-12-09T10:05:42.554899","updated":"2025-12-09T10:05:42.554907","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2ab4105-5176-4142-ac6e-dbac1ad81d3a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f2ab4105-5176-4142-ac6e-dbac1ad81d3a/pipeline.log\">pipeline</a>"]},{"id":"d981e4d0-a838-4bce-9500-228fa19eacea","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":925.171162,"created":"2025-12-09T10:12:09.566203","updated":"2025-12-09T10:12:09.566211","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d981e4d0-a838-4bce-9500-228fa19eacea\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d981e4d0-a838-4bce-9500-228fa19eacea/pipeline.log\">pipeline</a>"]},{"id":"aa3ab478-d864-4a84-a862-2397612321c5","name":"CentOS Stream 9 - PyTest - 20-minimal","status":"complete","outcome":"passed","runTime":904.939733,"created":"2025-12-09T10:14:45.871464","updated":"2025-12-09T10:14:45.871472","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/aa3ab478-d864-4a84-a862-2397612321c5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/aa3ab478-d864-4a84-a862-2397612321c5/pipeline.log\">pipeline</a>"]},{"id":"cd42db6e-f311-4bab-8a4d-12e09721e763","name":"RHEL9 - FIPS Enabled - 20-minimal","status":"complete","outcome":"passed","runTime":1512.06947,"created":"2025-12-09T10:05:22.973204","updated":"2025-12-09T10:05:22.973211","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd42db6e-f311-4bab-8a4d-12e09721e763\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cd42db6e-f311-4bab-8a4d-12e09721e763/pipeline.log\">pipeline</a>"]},{"id":"21415d67-43fc-4f80-8f37-b9d8134111aa","name":"RHEL9 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":1490.428802,"created":"2025-12-09T10:05:23.225251","updated":"2025-12-09T10:05:23.225257","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/21415d67-43fc-4f80-8f37-b9d8134111aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/21415d67-43fc-4f80-8f37-b9d8134111aa/pipeline.log\">pipeline</a>"]},{"id":"a2b33f23-a90b-4791-9b10-32a948d300d9","name":"RHEL9 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1481.332645,"created":"2025-12-09T10:05:30.328290","updated":"2025-12-09T10:05:30.328298","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2b33f23-a90b-4791-9b10-32a948d300d9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2b33f23-a90b-4791-9b10-32a948d300d9/pipeline.log\">pipeline</a>"]},{"id":"0e701140-6a5a-4990-974e-8d7f96b43f28","name":"Fedora - PyTest - 20","status":"complete","outcome":"passed","runTime":1107.612589,"created":"2025-12-09T10:11:45.007395","updated":"2025-12-09T10:11:45.007403","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0e701140-6a5a-4990-974e-8d7f96b43f28\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0e701140-6a5a-4990-974e-8d7f96b43f28/pipeline.log\">pipeline</a>"]},{"id":"8028664d-390e-4ec7-a57c-33cf8bc8ea66","name":"RHEL9 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1632.589528,"created":"2025-12-09T10:05:25.432935","updated":"2025-12-09T10:05:25.432942","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8028664d-390e-4ec7-a57c-33cf8bc8ea66\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8028664d-390e-4ec7-a57c-33cf8bc8ea66/pipeline.log\">pipeline</a>"]},{"id":"83bae8e4-efcb-4ed0-a8f5-805e0072df18","name":"RHEL9 - FIPS Enabled - 20","status":"complete","outcome":"passed","runTime":1583.018911,"created":"2025-12-09T10:05:26.043310","updated":"2025-12-09T10:05:26.043317","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/83bae8e4-efcb-4ed0-a8f5-805e0072df18\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/83bae8e4-efcb-4ed0-a8f5-805e0072df18/pipeline.log\">pipeline</a>"]},{"id":"1ab2be22-12e9-4867-959c-b371d0a91965","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":580.515555,"created":"2025-12-09T10:23:55.093686","updated":"2025-12-09T10:23:55.093692","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1ab2be22-12e9-4867-959c-b371d0a91965\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1ab2be22-12e9-4867-959c-b371d0a91965/pipeline.log\">pipeline</a>"]},{"id":"12966ad5-c62d-41b0-a82c-7e2eb1ba8aa0","name":"Fedora - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":783.032342,"created":"2025-12-09T10:23:52.844160","updated":"2025-12-09T10:23:52.844168","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/12966ad5-c62d-41b0-a82c-7e2eb1ba8aa0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/12966ad5-c62d-41b0-a82c-7e2eb1ba8aa0/pipeline.log\">pipeline</a>"]},{"id":"0c3d7395-e684-4997-a82a-d601e2e5a7dc","name":"RHEL10 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":876.243686,"created":"2025-12-09T10:25:08.794334","updated":"2025-12-09T10:25:08.794341","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c3d7395-e684-4997-a82a-d601e2e5a7dc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c3d7395-e684-4997-a82a-d601e2e5a7dc/pipeline.log\">pipeline</a>"]},{"id":"c590f8d4-36fc-4503-bc6f-cd7c64af5aad","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":535.265827,"created":"2025-12-09T10:31:41.217791","updated":"2025-12-09T10:31:41.217799","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c590f8d4-36fc-4503-bc6f-cd7c64af5aad\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c590f8d4-36fc-4503-bc6f-cd7c64af5aad/pipeline.log\">pipeline</a>"]},{"id":"29f9ba5b-95fc-4923-9f72-37410e598baa","name":"RHEL9 - Unsubscribed host - 22-minimal","status":"complete","outcome":"passed","runTime":977.897136,"created":"2025-12-09T10:25:46.076382","updated":"2025-12-09T10:25:46.076390","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/29f9ba5b-95fc-4923-9f72-37410e598baa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/29f9ba5b-95fc-4923-9f72-37410e598baa/pipeline.log\">pipeline</a>"]},{"id":"40ed1012-1f9c-4f20-a408-5ad7fb0205fe","name":"RHEL9 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1405.278024,"created":"2025-12-09T10:20:41.004791","updated":"2025-12-09T10:20:41.004800","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/40ed1012-1f9c-4f20-a408-5ad7fb0205fe\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/40ed1012-1f9c-4f20-a408-5ad7fb0205fe/pipeline.log\">pipeline</a>"]},{"id":"5ee04bda-ca8c-4cca-910c-991277ade2a8","name":"RHEL9 - Unsubscribed host - PyTest - 20","status":"complete","outcome":"passed","runTime":1076.006989,"created":"2025-12-09T10:28:06.292571","updated":"2025-12-09T10:28:06.292580","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ee04bda-ca8c-4cca-910c-991277ade2a8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ee04bda-ca8c-4cca-910c-991277ade2a8/pipeline.log\">pipeline</a>"]},{"id":"10677150-11b0-4380-8845-8b1d1b0231d3","name":"RHEL10 - PyTest - 24","status":"complete","outcome":"passed","runTime":1216.294439,"created":"2025-12-09T10:25:45.520562","updated":"2025-12-09T10:25:45.520570","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/10677150-11b0-4380-8845-8b1d1b0231d3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/10677150-11b0-4380-8845-8b1d1b0231d3/pipeline.log\">pipeline</a>"]},{"id":"87e6738e-e847-47e9-975f-40e8ebb1a75b","name":"Fedora - PyTest - 24","status":"complete","outcome":"passed","runTime":880.391823,"created":"2025-12-09T10:32:00.511235","updated":"2025-12-09T10:32:00.511244","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/87e6738e-e847-47e9-975f-40e8ebb1a75b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/87e6738e-e847-47e9-975f-40e8ebb1a75b/pipeline.log\">pipeline</a>"]},{"id":"fe40e08a-2e3a-4715-a3e3-24bbb39ddc4c","name":"RHEL9 - Unsubscribed host - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":983.809183,"created":"2025-12-09T10:31:07.557669","updated":"2025-12-09T10:31:07.557676","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe40e08a-2e3a-4715-a3e3-24bbb39ddc4c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fe40e08a-2e3a-4715-a3e3-24bbb39ddc4c/pipeline.log\">pipeline</a>"]},{"id":"1985845b-451e-4723-8c4a-7fe69c5ce75d","name":"RHEL9 - 24","status":"complete","outcome":"passed","runTime":1210.439291,"created":"2025-12-09T10:28:29.767968","updated":"2025-12-09T10:28:29.767974","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1985845b-451e-4723-8c4a-7fe69c5ce75d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1985845b-451e-4723-8c4a-7fe69c5ce75d/pipeline.log\">pipeline</a>"]},{"id":"bb981a97-8340-49ec-86b0-7a548eb95d99","name":"RHEL9 - PyTest - 24","status":"complete","outcome":"passed","runTime":1432.084138,"created":"2025-12-09T10:26:49.856340","updated":"2025-12-09T10:26:49.856347","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bb981a97-8340-49ec-86b0-7a548eb95d99\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bb981a97-8340-49ec-86b0-7a548eb95d99/pipeline.log\">pipeline</a>"]},{"id":"7cd02ec9-0340-4287-a8a8-897a0c931f5d","name":"RHEL10 - Unsubscribed host - PyTest - 22","status":"complete","outcome":"passed","runTime":1123.788944,"created":"2025-12-09T10:31:45.811021","updated":"2025-12-09T10:31:45.811027","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7cd02ec9-0340-4287-a8a8-897a0c931f5d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7cd02ec9-0340-4287-a8a8-897a0c931f5d/pipeline.log\">pipeline</a>"]},{"id":"6d114fff-85bb-439e-8881-3ac217cb5eaa","name":"RHEL9 - Unsubscribed host - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1071.081067,"created":"2025-12-09T10:34:11.526942","updated":"2025-12-09T10:34:11.526949","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d114fff-85bb-439e-8881-3ac217cb5eaa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d114fff-85bb-439e-8881-3ac217cb5eaa/pipeline.log\">pipeline</a>"]},{"id":"0a139ddf-2f37-42ae-9eca-9de24187c45a","name":"RHEL10 - Unsubscribed host - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1094.750125,"created":"2025-12-09T10:33:49.176473","updated":"2025-12-09T10:33:49.176482","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a139ddf-2f37-42ae-9eca-9de24187c45a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a139ddf-2f37-42ae-9eca-9de24187c45a/pipeline.log\">pipeline</a>"]},{"id":"37899589-bfb2-47a3-965e-0b59aeb17672","name":"RHEL9 - Unsubscribed host - 20-minimal","status":"complete","outcome":"passed","runTime":1115.446438,"created":"2025-12-09T10:33:55.213852","updated":"2025-12-09T10:33:55.213859","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/37899589-bfb2-47a3-965e-0b59aeb17672\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/37899589-bfb2-47a3-965e-0b59aeb17672/pipeline.log\">pipeline</a>"]},{"id":"9ea977f0-5afe-4113-bff9-d71c53b2eadb","name":"CentOS Stream 10 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":2826.116393,"created":"2025-12-09T10:05:54.777080","updated":"2025-12-09T10:05:54.777087","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9ea977f0-5afe-4113-bff9-d71c53b2eadb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9ea977f0-5afe-4113-bff9-d71c53b2eadb/pipeline.log\">pipeline</a>"]},{"id":"5542e879-7bea-4dca-b5ca-abd620bf341b","name":"Fedora - 24","status":"complete","outcome":"passed","runTime":591.905441,"created":"2025-12-09T10:44:02.304392","updated":"2025-12-09T10:44:02.304400","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5542e879-7bea-4dca-b5ca-abd620bf341b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5542e879-7bea-4dca-b5ca-abd620bf341b/pipeline.log\">pipeline</a>"]},{"id":"28f57e48-56df-46c7-86fe-2fdd1b714f23","name":"RHEL10 - 24-minimal","status":"complete","outcome":"passed","runTime":799.001471,"created":"2025-12-09T10:42:04.172952","updated":"2025-12-09T10:42:04.172959","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/28f57e48-56df-46c7-86fe-2fdd1b714f23\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/28f57e48-56df-46c7-86fe-2fdd1b714f23/pipeline.log\">pipeline</a>"]},{"id":"ec8616cb-0af1-4151-93cf-6aa7edf33933","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1519.356132,"created":"2025-12-09T10:31:39.626252","updated":"2025-12-09T10:31:39.626261","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec8616cb-0af1-4151-93cf-6aa7edf33933\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ec8616cb-0af1-4151-93cf-6aa7edf33933/pipeline.log\">pipeline</a>"]},{"id":"5540db23-8bf5-4743-841c-c0019f0427d8","name":"RHEL9 - PyTest - 20","status":"complete","outcome":"passed","runTime":1518.832869,"created":"2025-12-09T10:32:07.137077","updated":"2025-12-09T10:32:07.137085","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5540db23-8bf5-4743-841c-c0019f0427d8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5540db23-8bf5-4743-841c-c0019f0427d8/pipeline.log\">pipeline</a>"]},{"id":"2189d054-0633-4c34-809f-0fb6cb620cc1","name":"RHEL8 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1240.452714,"created":"2025-12-09T10:38:14.731133","updated":"2025-12-09T10:38:14.731141","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2189d054-0633-4c34-809f-0fb6cb620cc1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2189d054-0633-4c34-809f-0fb6cb620cc1/pipeline.log\">pipeline</a>"]},{"id":"fe8a2ce4-dd62-42b0-9c43-b53cfdc5c71a","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":613.537259,"created":"2025-12-09T10:48:26.897603","updated":"2025-12-09T10:48:26.897610","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fe8a2ce4-dd62-42b0-9c43-b53cfdc5c71a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fe8a2ce4-dd62-42b0-9c43-b53cfdc5c71a/pipeline.log\">pipeline</a>"]},{"id":"756ad01a-a31f-4b3e-8e82-ce65bbbb894b","name":"RHEL8 - 22-minimal","status":"complete","outcome":"passed","runTime":924.878642,"created":"2025-12-09T10:45:02.879072","updated":"2025-12-09T10:45:02.879077","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/756ad01a-a31f-4b3e-8e82-ce65bbbb894b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/756ad01a-a31f-4b3e-8e82-ce65bbbb894b/pipeline.log\">pipeline</a>"]},{"id":"19289da9-3dc4-463a-a9bb-dba8e1bd23d9","name":"CentOS Stream 10 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":863.99802,"created":"2025-12-09T10:46:33.774964","updated":"2025-12-09T10:46:33.774971","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/19289da9-3dc4-463a-a9bb-dba8e1bd23d9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/19289da9-3dc4-463a-a9bb-dba8e1bd23d9/pipeline.log\">pipeline</a>"]},{"id":"344edc23-3ed9-4176-923e-b69d97091021","name":"Fedora - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":790.570684,"created":"2025-12-09T10:49:29.022670","updated":"2025-12-09T10:49:29.022675","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/344edc23-3ed9-4176-923e-b69d97091021\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/344edc23-3ed9-4176-923e-b69d97091021/pipeline.log\">pipeline</a>"]},{"id":"3c530d3e-6668-4b90-96db-2f62b32c1711","name":"RHEL8 - PyTest - 20-minimal","status":"complete","outcome":"passed","runTime":1221.363842,"created":"2025-12-09T10:41:35.937437","updated":"2025-12-09T10:41:35.937447","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c530d3e-6668-4b90-96db-2f62b32c1711\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3c530d3e-6668-4b90-96db-2f62b32c1711/pipeline.log\">pipeline</a>"]},{"id":"22b0baea-02f9-41c4-af62-2722812d090b","name":"CentOS Stream 10 - 24-minimal","status":"complete","outcome":"passed","runTime":669.952762,"created":"2025-12-09T10:52:12.692429","updated":"2025-12-09T10:52:12.692436","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/22b0baea-02f9-41c4-af62-2722812d090b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/22b0baea-02f9-41c4-af62-2722812d090b/pipeline.log\">pipeline</a>"]},{"id":"f2707aa4-794e-4cad-984a-15bb7a130bb6","name":"Fedora - 24-minimal","status":"complete","outcome":"passed","runTime":520.148906,"created":"2025-12-09T10:54:19.122650","updated":"2025-12-09T10:54:19.122656","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f2707aa4-794e-4cad-984a-15bb7a130bb6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f2707aa4-794e-4cad-984a-15bb7a130bb6/pipeline.log\">pipeline</a>"]},{"id":"362e07de-fd11-498b-8213-05ab85303070","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":620.127425,"created":"2025-12-09T10:52:38.277058","updated":"2025-12-09T10:52:38.277066","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/362e07de-fd11-498b-8213-05ab85303070\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/362e07de-fd11-498b-8213-05ab85303070/pipeline.log\">pipeline</a>"]},{"id":"ed5f7fba-30f5-48b3-a012-405c2bad7ea2","name":"CentOS Stream 10 - PyTest - 24","status":"complete","outcome":"passed","runTime":921.691634,"created":"2025-12-09T10:50:46.404275","updated":"2025-12-09T10:50:46.404283","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ed5f7fba-30f5-48b3-a012-405c2bad7ea2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ed5f7fba-30f5-48b3-a012-405c2bad7ea2/pipeline.log\">pipeline</a>"]},{"id":"a7e99161-2d7d-4b83-8e6f-7f57c0807b9c","name":"RHEL10 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1122.203803,"created":"2025-12-09T10:48:01.801059","updated":"2025-12-09T10:48:01.801066","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7e99161-2d7d-4b83-8e6f-7f57c0807b9c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a7e99161-2d7d-4b83-8e6f-7f57c0807b9c/pipeline.log\">pipeline</a>"]},{"id":"46ae4e4d-3e72-4086-8ec0-2cb713480374","name":"RHEL8 - 22","status":"complete","outcome":"passed","runTime":1023.498828,"created":"2025-12-09T10:51:15.782480","updated":"2025-12-09T10:51:15.782490","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/46ae4e4d-3e72-4086-8ec0-2cb713480374\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/46ae4e4d-3e72-4086-8ec0-2cb713480374/pipeline.log\">pipeline</a>"]},{"id":"a2e98c52-0fed-4016-89b4-417bd438b0dd","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1026.829816,"created":"2025-12-09T10:54:20.742008","updated":"2025-12-09T10:54:20.742016","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2e98c52-0fed-4016-89b4-417bd438b0dd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2e98c52-0fed-4016-89b4-417bd438b0dd/pipeline.log\">pipeline</a>"]},{"id":"fb0b7a72-fd54-49f9-99a7-f9a0d119351c","name":"Fedora - PyTest - 20-minimal","status":"complete","outcome":"passed","runTime":895.227452,"created":"2025-12-09T10:56:33.054367","updated":"2025-12-09T10:56:33.054374","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/fb0b7a72-fd54-49f9-99a7-f9a0d119351c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/fb0b7a72-fd54-49f9-99a7-f9a0d119351c/pipeline.log\">pipeline</a>"]},{"id":"6320daa7-65ad-4bb9-a888-898c719837e6","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1156.1782,"created":"2025-12-09T10:54:22.805392","updated":"2025-12-09T10:54:22.805401","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6320daa7-65ad-4bb9-a888-898c719837e6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6320daa7-65ad-4bb9-a888-898c719837e6/pipeline.log\">pipeline</a>"]},{"id":"5e0cec22-52bc-4f35-a088-f916a757e715","name":"RHEL10 - Unsubscribed host - 22-minimal","status":"complete","outcome":"passed","runTime":847.520439,"created":"2025-12-09T10:58:31.324474","updated":"2025-12-09T10:58:31.324483","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e0cec22-52bc-4f35-a088-f916a757e715\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5e0cec22-52bc-4f35-a088-f916a757e715/pipeline.log\">pipeline</a>"]},{"id":"e5eb7185-8e7b-43fd-b866-9e7a91114678","name":"CentOS Stream 9 - 24-minimal","status":"complete","outcome":"passed","runTime":652.094369,"created":"2025-12-09T11:03:55.516687","updated":"2025-12-09T11:03:55.516696","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e5eb7185-8e7b-43fd-b866-9e7a91114678\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e5eb7185-8e7b-43fd-b866-9e7a91114678/pipeline.log\">pipeline</a>"]},{"id":"2783243e-ff6c-4d84-8d13-3e52e96e270b","name":"RHEL8 - PyTest - 22","status":"complete","outcome":"passed","runTime":1308.049333,"created":"2025-12-09T10:54:16.432577","updated":"2025-12-09T10:54:16.432586","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2783243e-ff6c-4d84-8d13-3e52e96e270b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2783243e-ff6c-4d84-8d13-3e52e96e270b/pipeline.log\">pipeline</a>"]},{"id":"bc0f4a1e-9c8c-4ce3-b77c-305e13b1d729","name":"RHEL9 - Unsubscribed host - PyTest - 20-minimal","status":"complete","outcome":"passed","runTime":939.273529,"created":"2025-12-09T11:00:47.861025","updated":"2025-12-09T11:00:47.861032","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bc0f4a1e-9c8c-4ce3-b77c-305e13b1d729\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bc0f4a1e-9c8c-4ce3-b77c-305e13b1d729/pipeline.log\">pipeline</a>"]},{"id":"f7bb17b5-8089-4eac-a9d7-da77644308a6","name":"CentOS Stream 9 - PyTest - 24","status":"complete","outcome":"passed","runTime":1085.949235,"created":"2025-12-09T10:58:02.701386","updated":"2025-12-09T10:58:02.701392","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f7bb17b5-8089-4eac-a9d7-da77644308a6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f7bb17b5-8089-4eac-a9d7-da77644308a6/pipeline.log\">pipeline</a>"]},{"id":"5bdd0e57-2214-4354-aa1d-c50488cb7491","name":"CentOS Stream 10 - 24","status":"complete","outcome":"passed","runTime":728.551816,"created":"2025-12-09T11:04:46.552936","updated":"2025-12-09T11:04:46.552944","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5bdd0e57-2214-4354-aa1d-c50488cb7491\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5bdd0e57-2214-4354-aa1d-c50488cb7491/pipeline.log\">pipeline</a>"]},{"id":"728ccec5-e58a-4b31-ae81-8d452819c5e5","name":"RHEL10 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":977.481837,"created":"2025-12-09T11:01:29.582350","updated":"2025-12-09T11:01:29.582357","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/728ccec5-e58a-4b31-ae81-8d452819c5e5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/728ccec5-e58a-4b31-ae81-8d452819c5e5/pipeline.log\">pipeline</a>"]},{"id":"4073cbc3-66b6-485b-b059-16deea7f2bd8","name":"RHEL8 - PyTest - 20","status":"complete","outcome":"passed","runTime":1285.092394,"created":"2025-12-09T11:00:45.861805","updated":"2025-12-09T11:00:45.861813","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4073cbc3-66b6-485b-b059-16deea7f2bd8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4073cbc3-66b6-485b-b059-16deea7f2bd8/pipeline.log\">pipeline</a>"]},{"id":"516328f8-3e21-4807-84c7-3a4b5c544c5a","name":"CentOS Stream 10 - PyTest - 22","status":"complete","outcome":"passed","runTime":993.391961,"created":"2025-12-09T11:04:59.493282","updated":"2025-12-09T11:04:59.493291","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/516328f8-3e21-4807-84c7-3a4b5c544c5a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/516328f8-3e21-4807-84c7-3a4b5c544c5a/pipeline.log\">pipeline</a>"]},{"id":"80ce8b0f-659f-44b8-9211-4ac0ef8d2cd2","name":"CentOS Stream 9 - PyTest - 20","status":"complete","outcome":"passed","runTime":1025.348324,"created":"2025-12-09T11:07:11.122395","updated":"2025-12-09T11:07:11.122403","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/80ce8b0f-659f-44b8-9211-4ac0ef8d2cd2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/80ce8b0f-659f-44b8-9211-4ac0ef8d2cd2/pipeline.log\">pipeline</a>"]},{"id":"2a17d743-0ccb-45dd-b5f4-029664795933","name":"RHEL9 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":986.344492,"created":"2025-12-09T11:09:34.965512","updated":"2025-12-09T11:09:34.965519","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a17d743-0ccb-45dd-b5f4-029664795933\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2a17d743-0ccb-45dd-b5f4-029664795933/pipeline.log\">pipeline</a>"]},{"id":"8dd40b85-4142-4599-b6dd-b9df33a81bcc","name":"RHEL9 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1419.436091,"created":"2025-12-09T11:03:58.650287","updated":"2025-12-09T11:03:58.650296","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8dd40b85-4142-4599-b6dd-b9df33a81bcc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8dd40b85-4142-4599-b6dd-b9df33a81bcc/pipeline.log\">pipeline</a>"]},{"id":"a2d08700-39b6-4d77-8771-2e16621f72e5","name":"RHEL9 - 24-minimal","status":"complete","outcome":"passed","runTime":1238.352146,"created":"2025-12-09T11:06:35.772038","updated":"2025-12-09T11:06:35.772044","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2d08700-39b6-4d77-8771-2e16621f72e5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a2d08700-39b6-4d77-8771-2e16621f72e5/pipeline.log\">pipeline</a>"]},{"id":"67606d1e-e40c-47aa-a0e5-605298370120","name":"RHEL9 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":1446.876596,"created":"2025-12-09T11:04:13.865048","updated":"2025-12-09T11:04:13.865057","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67606d1e-e40c-47aa-a0e5-605298370120\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67606d1e-e40c-47aa-a0e5-605298370120/pipeline.log\">pipeline</a>"]},{"id":"abcae9b2-1dae-4b1a-aba6-e688c147b25e","name":"CentOS Stream 9 - 24","status":"complete","outcome":"passed","runTime":805.453647,"created":"2025-12-09T11:17:05.050772","updated":"2025-12-09T11:17:05.050779","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/abcae9b2-1dae-4b1a-aba6-e688c147b25e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/abcae9b2-1dae-4b1a-aba6-e688c147b25e/pipeline.log\">pipeline</a>"]},{"id":"ef62b0f0-07d7-460b-b2dd-dd586e0dd465","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":649.351637,"created":"2025-12-09T11:20:14.487547","updated":"2025-12-09T11:20:14.487553","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ef62b0f0-07d7-460b-b2dd-dd586e0dd465\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ef62b0f0-07d7-460b-b2dd-dd586e0dd465/pipeline.log\">pipeline</a>"]},{"id":"c5fdff1b-4d74-4b50-8044-ac9545015f6f","name":"RHEL10 - 24","status":"complete","outcome":"passed","runTime":953.779935,"created":"2025-12-09T11:16:39.411341","updated":"2025-12-09T11:16:39.411348","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c5fdff1b-4d74-4b50-8044-ac9545015f6f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c5fdff1b-4d74-4b50-8044-ac9545015f6f/pipeline.log\">pipeline</a>"]},{"id":"72cf0419-9c30-4840-978e-0d9f1afddd51","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":1111.464697,"created":"2025-12-09T11:14:25.353008","updated":"2025-12-09T11:14:25.353018","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/72cf0419-9c30-4840-978e-0d9f1afddd51\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/72cf0419-9c30-4840-978e-0d9f1afddd51/pipeline.log\">pipeline</a>"]},{"id":"c6723350-5402-476e-b9d2-e173f59164d6","name":"RHEL9 - Unsubscribed host - PyTest - 22","status":"complete","outcome":"passed","runTime":1098.56552,"created":"2025-12-09T11:14:33.709431","updated":"2025-12-09T11:14:33.709439","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c6723350-5402-476e-b9d2-e173f59164d6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c6723350-5402-476e-b9d2-e173f59164d6/pipeline.log\">pipeline</a>"]},{"id":"79be3c8e-3184-4b92-a208-ca17bd6b77d8","name":"RHEL10 - PyTest - 22","status":"complete","outcome":"passed","runTime":1149.503361,"created":"2025-12-09T11:14:52.886897","updated":"2025-12-09T11:14:52.886903","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/79be3c8e-3184-4b92-a208-ca17bd6b77d8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/79be3c8e-3184-4b92-a208-ca17bd6b77d8/pipeline.log\">pipeline</a>"]},{"id":"0a6ec229-4fea-4c6c-baec-a5948a9ad780","name":"RHEL10 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":871.333702,"created":"2025-12-09T11:19:53.572729","updated":"2025-12-09T11:19:53.572737","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a6ec229-4fea-4c6c-baec-a5948a9ad780\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a6ec229-4fea-4c6c-baec-a5948a9ad780/pipeline.log\">pipeline</a>"]},{"id":"f386c030-f60a-4b7c-a481-3b7e7b55ab08","name":"RHEL9 - PyTest - 22","status":"complete","outcome":"passed","runTime":1538.999988,"created":"2025-12-09T11:10:24.592967","updated":"2025-12-09T11:10:24.592975","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f386c030-f60a-4b7c-a481-3b7e7b55ab08\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f386c030-f60a-4b7c-a481-3b7e7b55ab08/pipeline.log\">pipeline</a>"]},{"id":"75ac91c2-5c8e-4b68-a1a8-50bcce7d980e","name":"RHEL9 - Unsubscribed host - 20","status":"complete","outcome":"passed","runTime":1123.509764,"created":"2025-12-09T11:16:52.894506","updated":"2025-12-09T11:16:52.894512","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/75ac91c2-5c8e-4b68-a1a8-50bcce7d980e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/75ac91c2-5c8e-4b68-a1a8-50bcce7d980e/pipeline.log\">pipeline</a>"]},{"id":"30f7f21b-2747-466c-a53e-0c088c274204","name":"RHEL9 - PyTest - 20-minimal","status":"complete","outcome":"passed","runTime":1362.912125,"created":"2025-12-09T11:14:49.080746","updated":"2025-12-09T11:14:49.080755","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/30f7f21b-2747-466c-a53e-0c088c274204\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/30f7f21b-2747-466c-a53e-0c088c274204/pipeline.log\">pipeline</a>"]},{"id":"1a01d862-3942-4dbc-b4f9-c610d6d41d31","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":525.591478,"created":"2025-12-09T11:29:41.409011","updated":"2025-12-09T11:29:41.409017","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1a01d862-3942-4dbc-b4f9-c610d6d41d31\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1a01d862-3942-4dbc-b4f9-c610d6d41d31/pipeline.log\">pipeline</a>"]},{"id":"ed7115bf-bf4d-4674-9def-067f5ec652f4","name":"RHEL9 - Unsubscribed host - PyTest - 24","status":"complete","outcome":"passed","runTime":1058.041875,"created":"2025-12-09T11:25:29.561259","updated":"2025-12-09T11:25:29.561268","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ed7115bf-bf4d-4674-9def-067f5ec652f4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ed7115bf-bf4d-4674-9def-067f5ec652f4/pipeline.log\">pipeline</a>"]},{"id":"f34c5873-b046-4a53-b38a-07e898bfaa69","name":"Fedora - PyTest - 22","status":"complete","outcome":"passed","runTime":906.278175,"created":"2025-12-09T11:28:31.310870","updated":"2025-12-09T11:28:31.310878","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f34c5873-b046-4a53-b38a-07e898bfaa69\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f34c5873-b046-4a53-b38a-07e898bfaa69/pipeline.log\">pipeline</a>"]},{"id":"ac1c0017-0893-4ac5-a9c4-d87ec5d8e503","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":1283.431041,"created":"2025-12-09T11:23:13.035793","updated":"2025-12-09T11:23:13.035800","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ac1c0017-0893-4ac5-a9c4-d87ec5d8e503\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ac1c0017-0893-4ac5-a9c4-d87ec5d8e503/pipeline.log\">pipeline</a>"]},{"id":"9bef850e-262a-4b86-97ff-82db94dfb1be","name":"RHEL10 - Unsubscribed host - PyTest - 24","status":"complete","outcome":"passed","runTime":1106.401657,"created":"2025-12-09T11:25:14.184676","updated":"2025-12-09T11:25:14.184685","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bef850e-262a-4b86-97ff-82db94dfb1be\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9bef850e-262a-4b86-97ff-82db94dfb1be/pipeline.log\">pipeline</a>"]},{"id":"7dcabb73-53e9-4fdc-a7cb-0bdd3fcac1d2","name":"RHEL10 - Unsubscribed host - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1051.302149,"created":"2025-12-09T11:29:07.150514","updated":"2025-12-09T11:29:07.150521","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7dcabb73-53e9-4fdc-a7cb-0bdd3fcac1d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7dcabb73-53e9-4fdc-a7cb-0bdd3fcac1d2/pipeline.log\">pipeline</a>"]},{"id":"b44b737e-3770-4f6d-9252-5a9d783aa31b","name":"RHEL9 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":1079.036119,"created":"2025-12-09T11:30:46.972099","updated":"2025-12-09T11:30:46.972106","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b44b737e-3770-4f6d-9252-5a9d783aa31b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b44b737e-3770-4f6d-9252-5a9d783aa31b/pipeline.log\">pipeline</a>"]},{"id":"6ef5e372-c3fb-41a8-b2cb-be7e27ad8c6e","name":"RHEL10 - PyTest - 24-minimal","runTime":1102.534114,"created":"2025-12-09T11:31:26.360228","updated":"2025-12-09T11:31:26.360236","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ef5e372-c3fb-41a8-b2cb-be7e27ad8c6e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ef5e372-c3fb-41a8-b2cb-be7e27ad8c6e/pipeline.log\">pipeline</a>"]}]} -->