### PR TITLE
Allow NPM_TOKEN for downloading package from private repositories.

### DIFF
--- a/20-minimal/README.md
+++ b/20-minimal/README.md
@@ -232,6 +232,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_MIRROR`**  
        Use a custom NPM registry mirror to download packages during the build process
 
+**`NPM_TOKEN`**
+       Use authentication token for a custom NPM registry mirror
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/20-minimal/s2i/bin/assemble
+++ b/20-minimal/s2i/bin/assemble
@@ -63,6 +63,13 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
+# Change the npm authentication token if provided
+if [ -n "$NPM_TOKEN" ]; then
+	echo "---> Setting npm authentication token for $NPM_MIRROR"
+	INTERNAL_NPM_REGISTRY=$(echo "$NPM_MIRROR" | sed -n 's|https://||p')
+	npm config set "//${INTERNAL_NPM_REGISTRY:-registry.npmjs.org}:_auth" $NPM_TOKEN
+fi
+
 # Set the DEV_MODE to false by default.
 if [ -z "$DEV_MODE" ]; then
   export DEV_MODE=false

--- a/20/README.md
+++ b/20/README.md
@@ -160,6 +160,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_MIRROR`**  
        Use a custom NPM registry mirror to download packages during the build process
 
+**`NPM_TOKEN`**
+       Use authentication token for a custom NPM registry mirror
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/20/s2i/bin/assemble
+++ b/20/s2i/bin/assemble
@@ -63,6 +63,13 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
+# Change the npm authentication token if provided
+if [ -n "$NPM_TOKEN" ]; then
+	echo "---> Setting npm authentication token for $NPM_MIRROR"
+	INTERNAL_NPM_REGISTRY=$(echo "$NPM_MIRROR" | sed -n 's|https://||p')
+	npm config set "//${INTERNAL_NPM_REGISTRY:-registry.npmjs.org}:_auth" $NPM_TOKEN
+fi
+
 # Set the DEV_MODE to false by default.
 if [ -z "$DEV_MODE" ]; then
   export DEV_MODE=false

--- a/22-minimal/README.md
+++ b/22-minimal/README.md
@@ -232,6 +232,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_MIRROR`**  
        Use a custom NPM registry mirror to download packages during the build process
 
+**`NPM_TOKEN`**
+       Use authentication token for a custom NPM registry mirror
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/22-minimal/s2i/bin/assemble
+++ b/22-minimal/s2i/bin/assemble
@@ -63,6 +63,13 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
+# Change the npm authentication token if provided
+if [ -n "$NPM_TOKEN" ]; then
+	echo "---> Setting npm authentication token for $NPM_MIRROR"
+	INTERNAL_NPM_REGISTRY=$(echo "$NPM_MIRROR" | sed -n 's|https://||p')
+	npm config set "//${INTERNAL_NPM_REGISTRY:-registry.npmjs.org}:_auth" $NPM_TOKEN
+fi
+
 # Set the DEV_MODE to false by default.
 if [ -z "$DEV_MODE" ]; then
   export DEV_MODE=false

--- a/22/README.md
+++ b/22/README.md
@@ -160,6 +160,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_MIRROR`**  
        Use a custom NPM registry mirror to download packages during the build process
 
+**`NPM_TOKEN`**
+       Use authentication token for a custom NPM registry mirror
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/22/s2i/bin/assemble
+++ b/22/s2i/bin/assemble
@@ -63,6 +63,13 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
+# Change the npm authentication token if provided
+if [ -n "$NPM_TOKEN" ]; then
+	echo "---> Setting npm authentication token for $NPM_MIRROR"
+	INTERNAL_NPM_REGISTRY=$(echo "$NPM_MIRROR" | sed -n 's|https://||p')
+	npm config set "//${INTERNAL_NPM_REGISTRY:-registry.npmjs.org}:_auth" $NPM_TOKEN
+fi
+
 # Set the DEV_MODE to false by default.
 if [ -z "$DEV_MODE" ]; then
   export DEV_MODE=false

--- a/24-minimal/README.md
+++ b/24-minimal/README.md
@@ -232,6 +232,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_MIRROR`**  
        Use a custom NPM registry mirror to download packages during the build process
 
+**`NPM_TOKEN`**
+       Use authentication token for a custom NPM registry mirror
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/24-minimal/s2i/bin/assemble
+++ b/24-minimal/s2i/bin/assemble
@@ -63,6 +63,13 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
+# Change the npm authentication token if provided
+if [ -n "$NPM_TOKEN" ]; then
+	echo "---> Setting npm authentication token for $NPM_MIRROR"
+	INTERNAL_NPM_REGISTRY=$(echo "$NPM_MIRROR" | sed -n 's|https://||p')
+	npm config set "//${INTERNAL_NPM_REGISTRY:-registry.npmjs.org}:_auth" $NPM_TOKEN
+fi
+
 # Set the DEV_MODE to false by default.
 if [ -z "$DEV_MODE" ]; then
   export DEV_MODE=false

--- a/24/README.md
+++ b/24/README.md
@@ -160,6 +160,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_MIRROR`**  
        Use a custom NPM registry mirror to download packages during the build process
 
+**`NPM_TOKEN`**
+       Use authentication token for a custom NPM registry mirror
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/24/s2i/bin/assemble
+++ b/24/s2i/bin/assemble
@@ -63,6 +63,13 @@ if [ -n "$NPM_MIRROR" ]; then
 	npm config set registry $NPM_MIRROR
 fi
 
+# Change the npm authentication token if provided
+if [ -n "$NPM_TOKEN" ]; then
+	echo "---> Setting npm authentication token for $NPM_MIRROR"
+	INTERNAL_NPM_REGISTRY=$(echo "$NPM_MIRROR" | sed -n 's|https://||p')
+	npm config set "//${INTERNAL_NPM_REGISTRY:-registry.npmjs.org}:_auth" $NPM_TOKEN
+fi
+
 # Set the DEV_MODE to false by default.
 if [ -z "$DEV_MODE" ]; then
   export DEV_MODE=false

--- a/test/run
+++ b/test/run
@@ -29,6 +29,12 @@ test_init_wrapper_true_development
 test_init_wrapper_false_development
 "
 
+TEST_LIST_NPM_TOKEN="\
+test_run_app_application
+test_connection
+test_npm_token_present
+"
+
 TEST_LIST_NODE_ENV="\
 test_run_app_application
 test_connection
@@ -137,6 +143,16 @@ run_s2i_build
 evaluate_build_result $? "default"
 
 TEST_SET=${TESTS:-$TEST_LIST_APP} ct_run_tests_from_testset "app"
+
+cleanup
+
+prepare app
+check_prep_result $? app || exit
+echo "Testing the production image build with token"
+run_s2i_build "-e NPM_TOKEN=some-token-for-testing"
+evaluate_build_result $? "-e NPM_TOKEN=some-token-for-testing"
+
+TEST_SET=${TESTS:-$TEST_LIST_NPM_TOKEN} ct_run_tests_from_testset "node_env_token"
 
 cleanup
 

--- a/test/test-lib-nodejs.sh
+++ b/test/test-lib-nodejs.sh
@@ -518,6 +518,18 @@ function test_npm_cache_exists() {
   ct_check_testcase_result "$?"
 }
 
+function test_npm_token_present() {
+  # Test that the npm token has been set
+	INTERNAL_NPM_REGISTRY=$(echo "$NPM_MIRROR" | sed -n 's|https://||p')
+  AUTH_TOKEN="//${INTERNAL_NPM_REGISTRY:-registry.npmjs.org}:_auth"
+  auth_token=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "npm config list | grep -E '^${AUTH_TOKEN}'")
+  ct_check_testcase_result "$?"
+  npmrc_file=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "cat .npmrc")
+  ct_check_testcase_result "$?"
+  echo "$npmrc_file" | grep "${AUTH_TOKEN}=some-token-for-testing"
+  ct_check_testcase_result "$?"
+}
+
 function test_npm_tmp_cleared() {
   # Test that the npm tmp has been cleared
   devdep=$(docker run --rm ${IMAGE_NAME}-testapp /bin/bash -c "! ls \$(npm config get tmp)/npm-* 2>/dev/null")

--- a/test/test_container_apps.py
+++ b/test/test_container_apps.py
@@ -1,4 +1,5 @@
 import re
+import os
 
 from pathlib import Path
 
@@ -490,3 +491,60 @@ class TestNodeJSIncrementalAppContainer:
         build_log1 = self.build1.get_podman_build_log_file()
         build_log2 = self.build2.get_podman_build_log_file()
         assert build_log1 != build_log2
+
+
+class TestNodeJSAuthenticationTokenAppContainer:
+    """
+    Test npm authentication token of a NodeJS application.
+    """
+
+    def setup_method(self):
+        """
+        Setup the test environment.
+        """
+        self.s2i_app = build_s2i_app(
+            test_app, container_args="-e NPM_TOKEN=some-token-for-testing"
+        )
+
+    def teardown_method(self):
+        """
+        Cleanup the test environment.
+        """
+        self.s2i_app.cleanup()
+
+    def test_npm_authentication_token(self):
+        """
+        Test npm authentication token of a NodeJS application.
+        """
+        assert self.s2i_app.create_container(
+            cid_file_name=self.s2i_app.app_name,
+            container_args="-e NPM_TOKEN=some-token-for-testing",
+        )
+        cip, cid = self.s2i_app.get_cip_cid(cid_file_name=self.s2i_app.app_name)
+        assert cip, cid
+        assert self.s2i_app.test_response(url=f"http://{cip}")
+        INTERNAL_NPM_REGISTRY = (
+            os.getenv("NPM_MIRROR").replace("https://", "")
+            if os.getenv("NPM_MIRROR")
+            else "registry.npmjs.org"
+        )
+        NPM_REGISTRY_AUTH = f"//{INTERNAL_NPM_REGISTRY}:_auth"
+        npm_config_list = PodmanCLIWrapper.podman_run_command_and_remove(
+            cid_file_name=f"{VARS.IMAGE_NAME}-{self.s2i_app.app_name}",
+            cmd="npm config list",
+        )
+        pattern = rf"{NPM_REGISTRY_AUTH}\s*=\s*\(protected\)"
+        for line in npm_config_list.split("\n"):
+            if re.search(pattern, line):
+                print("Line found")
+                break
+        else:
+            assert False, (
+                f"Auth registry {NPM_REGISTRY_AUTH} not found in npm config list"
+            )
+        npmrc_file = PodmanCLIWrapper.podman_run_command_and_remove(
+            cid_file_name=f"{VARS.IMAGE_NAME}-{self.s2i_app.app_name}",
+            cmd="cat .npmrc",
+        ).strip()
+        pattern_file = rf"{NPM_REGISTRY_AUTH}=some-token-for-testing"
+        assert re.search(pattern_file, npmrc_file)


### PR DESCRIPTION
Add support NPM_TOKEN for successfully downloading

npm packages from private NPM repositories.

The pull request also contains test suite as for
BASH as for PyThon.

See Jira issue: https://issues.redhat.com/browse/RHEL-113826

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- testing-farm = {"lock":"false","comment-id":"3768316481","data":[{"id":"1998432d-8248-4667-89db-61158697ae68","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":743.853765,"created":"2026-01-20T06:57:07.632846","updated":"2026-01-20T06:57:07.632854","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1998432d-8248-4667-89db-61158697ae68\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1998432d-8248-4667-89db-61158697ae68/pipeline.log\">pipeline</a>"]},{"id":"f04abd82-62ea-45c0-99c3-6e311fceed2f","name":"CentOS Stream 9 - PyTest - 24","status":"complete","outcome":"passed","runTime":1052.815324,"created":"2026-01-20T06:50:51.062367","updated":"2026-01-20T06:50:51.062373","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f04abd82-62ea-45c0-99c3-6e311fceed2f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f04abd82-62ea-45c0-99c3-6e311fceed2f/pipeline.log\">pipeline</a>"]},{"id":"6f2f5664-ffc1-4b20-bfe2-91c6f062c382","name":"RHEL9 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":1517.843034,"created":"2026-01-20T06:30:34.346511","updated":"2026-01-20T06:30:34.346517","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f2f5664-ffc1-4b20-bfe2-91c6f062c382\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f2f5664-ffc1-4b20-bfe2-91c6f062c382/pipeline.log\">pipeline</a>"]},{"id":"1f06baab-909a-4e1b-8ee1-87c44afad94a","name":"Fedora - PyTest - 20","status":"complete","outcome":"passed","runTime":998.480523,"created":"2026-01-19T16:34:02.905720","updated":"2026-01-19T16:34:02.905726","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1f06baab-909a-4e1b-8ee1-87c44afad94a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1f06baab-909a-4e1b-8ee1-87c44afad94a/pipeline.log\">pipeline</a>"]},{"id":"a85212b1-ef1d-4906-805b-83993e003890","name":"RHEL10 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":9002.964253,"created":"2026-01-19T13:10:08.539363","updated":"2026-01-19T13:10:08.539371","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a85212b1-ef1d-4906-805b-83993e003890\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a85212b1-ef1d-4906-805b-83993e003890/pipeline.log\">pipeline</a>"]},{"id":"067cd4d2-b526-45cc-bd1a-86d968146266","name":"RHEL10 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":4307.197768,"created":"2026-01-19T16:34:01.924072","updated":"2026-01-19T16:34:01.924082","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/067cd4d2-b526-45cc-bd1a-86d968146266\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/067cd4d2-b526-45cc-bd1a-86d968146266/pipeline.log\">pipeline</a>"]},{"id":"075479c9-1c38-4cd9-b2a1-c591fb5690aa","name":"RHEL10 - PyTest - 24","runTime":1183.155032,"created":"2026-01-20T07:49:34.348039","updated":"2026-01-20T07:49:34.348047","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/075479c9-1c38-4cd9-b2a1-c591fb5690aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/075479c9-1c38-4cd9-b2a1-c591fb5690aa/pipeline.log\">pipeline</a>"]},{"id":"e2bc3a4c-f2b2-4049-9056-ea17405944a1","name":"RHEL10 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":4512.532116,"created":"2026-01-19T16:34:01.968400","updated":"2026-01-19T16:34:01.968408","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e2bc3a4c-f2b2-4049-9056-ea17405944a1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e2bc3a4c-f2b2-4049-9056-ea17405944a1/pipeline.log\">pipeline</a>"]},{"id":"ff01d477-6176-4a76-b93e-269f3eb5d6aa","name":"RHEL9 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":1429.056498,"created":"2026-01-20T06:30:34.532546","updated":"2026-01-20T06:30:34.532554","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ff01d477-6176-4a76-b93e-269f3eb5d6aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ff01d477-6176-4a76-b93e-269f3eb5d6aa/pipeline.log\">pipeline</a>"]},{"id":"c0300f43-3167-44b5-905e-c4e1df25d67b","name":"RHEL9 - FIPS Enabled - 20-minimal","status":"complete","outcome":"passed","runTime":1431.925344,"created":"2026-01-20T06:30:34.671966","updated":"2026-01-20T06:30:34.671974","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0300f43-3167-44b5-905e-c4e1df25d67b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0300f43-3167-44b5-905e-c4e1df25d67b/pipeline.log\">pipeline</a>"]},{"id":"de9d01b6-75f2-49a8-b74b-ed4c13126389","name":"RHEL9 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1481.426832,"created":"2026-01-20T06:30:32.595425","updated":"2026-01-20T06:30:32.595431","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/de9d01b6-75f2-49a8-b74b-ed4c13126389\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/de9d01b6-75f2-49a8-b74b-ed4c13126389/pipeline.log\">pipeline</a>"]},{"id":"8da8bde0-c212-4f37-8be2-8386ffe8eb06","name":"RHEL9 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1562.605883,"created":"2026-01-20T06:30:33.465879","updated":"2026-01-20T06:30:33.465885","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8da8bde0-c212-4f37-8be2-8386ffe8eb06\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8da8bde0-c212-4f37-8be2-8386ffe8eb06/pipeline.log\">pipeline</a>"]},{"id":"26603f71-7d4a-4396-af8b-0dcb948cafd7","name":"Fedora - 24","status":"complete","outcome":"passed","runTime":580.5626,"created":"2026-01-20T07:11:18.557962","updated":"2026-01-20T07:11:18.557970","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/26603f71-7d4a-4396-af8b-0dcb948cafd7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/26603f71-7d4a-4396-af8b-0dcb948cafd7/pipeline.log\">pipeline</a>"]},{"id":"420e6c46-18ab-47b5-8fc6-d83e8c37739b","name":"RHEL9 - FIPS Enabled - 20","status":"complete","outcome":"passed","runTime":9676.668387,"created":"2026-01-19T13:10:07.768146","updated":"2026-01-19T13:10:07.768155","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/420e6c46-18ab-47b5-8fc6-d83e8c37739b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/420e6c46-18ab-47b5-8fc6-d83e8c37739b/pipeline.log\">pipeline</a>"]},{"id":"7502ac8d-918f-4af4-846e-7b587f6df550","name":"CentOS Stream 9 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1875.44491,"created":"2026-01-19T17:08:53.521321","updated":"2026-01-19T17:08:53.521330","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7502ac8d-918f-4af4-846e-7b587f6df550\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7502ac8d-918f-4af4-846e-7b587f6df550/pipeline.log\">pipeline</a>"]},{"id":"41e93ddf-a4c5-40ab-ac07-64ebfb0f9b6f","name":"CentOS Stream 10 - PyTest - 22","status":"complete","outcome":"passed","runTime":934.062191,"created":"2026-01-20T06:55:01.151813","updated":"2026-01-20T06:55:01.151819","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/41e93ddf-a4c5-40ab-ac07-64ebfb0f9b6f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/41e93ddf-a4c5-40ab-ac07-64ebfb0f9b6f/pipeline.log\">pipeline</a>"]},{"id":"3003a50f-b277-4608-ab50-6dbf0860992d","name":"RHEL10 - Unsubscribed host - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":4387.945393,"created":"2026-01-19T16:34:10.381940","updated":"2026-01-19T16:34:10.381946","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3003a50f-b277-4608-ab50-6dbf0860992d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3003a50f-b277-4608-ab50-6dbf0860992d/pipeline.log\">pipeline</a>"]},{"id":"35c4466d-ff17-4840-b64e-ebc56269ae88","name":"Fedora - 20","status":"complete","outcome":"passed","runTime":589.025736,"created":"2026-01-20T07:21:30.271650","updated":"2026-01-20T07:21:30.271658","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/35c4466d-ff17-4840-b64e-ebc56269ae88\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/35c4466d-ff17-4840-b64e-ebc56269ae88/pipeline.log\">pipeline</a>"]},{"id":"a2a1f37e-caf2-42b6-9be5-c75804750c2c","name":"Fedora - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":679.315062,"created":"2026-01-20T07:07:20.706678","updated":"2026-01-20T07:07:20.706684","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a2a1f37e-caf2-42b6-9be5-c75804750c2c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a2a1f37e-caf2-42b6-9be5-c75804750c2c/pipeline.log\">pipeline</a>"]},{"id":"0597177b-5bd5-49ce-b36d-fbcdf0ab7fea","name":"Fedora - 24-minimal","status":"complete","outcome":"passed","runTime":403.065556,"created":"2026-01-19T16:34:14.298385","updated":"2026-01-19T16:34:14.298393","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0597177b-5bd5-49ce-b36d-fbcdf0ab7fea\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0597177b-5bd5-49ce-b36d-fbcdf0ab7fea/pipeline.log\">pipeline</a>"]},{"id":"53ddc2e2-bd3b-4125-b378-9e72b2a70f41","name":"CentOS Stream 9 - 24-minimal","status":"complete","outcome":"passed","runTime":760.23748,"created":"2026-01-19T16:34:12.331484","updated":"2026-01-19T16:34:12.331491","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/53ddc2e2-bd3b-4125-b378-9e72b2a70f41\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/53ddc2e2-bd3b-4125-b378-9e72b2a70f41/pipeline.log\">pipeline</a>"]},{"id":"a648796e-6e75-4da9-9a6f-ea0070e9a858","name":"CentOS Stream 10 - 24","status":"complete","outcome":"passed","runTime":746.224521,"created":"2026-01-19T16:34:26.426240","updated":"2026-01-19T16:34:26.426249","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a648796e-6e75-4da9-9a6f-ea0070e9a858\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a648796e-6e75-4da9-9a6f-ea0070e9a858/pipeline.log\">pipeline</a>"]},{"id":"8684cb16-b2af-402d-9bc4-e4659b49770f","name":"Fedora - PyTest - 20-minimal","status":"complete","outcome":"passed","runTime":872.10155,"created":"2026-01-19T16:34:03.408924","updated":"2026-01-19T16:34:03.408931","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8684cb16-b2af-402d-9bc4-e4659b49770f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8684cb16-b2af-402d-9bc4-e4659b49770f/pipeline.log\">pipeline</a>"]},{"id":"a1124fea-ec31-4f3a-9934-e5be9224d417","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":592.108068,"created":"2026-01-19T16:42:34.625806","updated":"2026-01-19T16:42:34.625817","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a1124fea-ec31-4f3a-9934-e5be9224d417\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a1124fea-ec31-4f3a-9934-e5be9224d417/pipeline.log\">pipeline</a>"]},{"id":"e4e5e865-e4b1-4829-867c-cccd5809c6a7","name":"Fedora - 20-minimal","status":"complete","outcome":"passed","runTime":471.213894,"created":"2026-01-19T16:48:48.785433","updated":"2026-01-19T16:48:48.785439","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e4e5e865-e4b1-4829-867c-cccd5809c6a7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e4e5e865-e4b1-4829-867c-cccd5809c6a7/pipeline.log\">pipeline</a>"]},{"id":"7ef91cae-d2ab-42b5-9ef7-55a8914dffb9","name":"CentOS Stream 9 - 24","status":"complete","outcome":"passed","runTime":959.455825,"created":"2026-01-19T16:52:26.601923","updated":"2026-01-19T16:52:26.601930","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7ef91cae-d2ab-42b5-9ef7-55a8914dffb9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7ef91cae-d2ab-42b5-9ef7-55a8914dffb9/pipeline.log\">pipeline</a>"]},{"id":"8c43af46-9d28-4a1e-b907-eea0753a0851","name":"RHEL10 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":4396.170651,"created":"2026-01-19T16:34:03.495301","updated":"2026-01-19T16:34:03.495309","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c43af46-9d28-4a1e-b907-eea0753a0851\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c43af46-9d28-4a1e-b907-eea0753a0851/pipeline.log\">pipeline</a>"]},{"id":"67c8017e-8fd2-4ce2-97d3-37b31aa39a02","name":"RHEL9 - Unsubscribed host - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":4364.062439,"created":"2026-01-19T16:34:09.854473","updated":"2026-01-19T16:34:09.854500","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67c8017e-8fd2-4ce2-97d3-37b31aa39a02\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67c8017e-8fd2-4ce2-97d3-37b31aa39a02/pipeline.log\">pipeline</a>"]},{"id":"0c1c86c2-8ca6-40d1-9833-291bdfceb316","name":"RHEL8 - PyTest - 20","status":"complete","outcome":"passed","runTime":4555.89808,"created":"2026-01-19T16:34:02.493612","updated":"2026-01-19T16:34:02.493619","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c1c86c2-8ca6-40d1-9833-291bdfceb316\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c1c86c2-8ca6-40d1-9833-291bdfceb316/pipeline.log\">pipeline</a>"]},{"id":"af7c7ad3-4826-41aa-ba78-a1e2142aeef2","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":457.371062,"created":"2026-01-20T06:30:33.721253","updated":"2026-01-20T06:30:33.721261","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/af7c7ad3-4826-41aa-ba78-a1e2142aeef2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/af7c7ad3-4826-41aa-ba78-a1e2142aeef2/pipeline.log\">pipeline</a>"]},{"id":"580d82f2-f73f-41c4-b1b3-c518eed38670","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":569.185995,"created":"2026-01-20T06:30:35.308842","updated":"2026-01-20T06:30:35.308848","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/580d82f2-f73f-41c4-b1b3-c518eed38670\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/580d82f2-f73f-41c4-b1b3-c518eed38670/pipeline.log\">pipeline</a>"]},{"id":"0769fb17-dbba-454e-b429-45001da0072f","name":"RHEL10 - Unsubscribed host - 22-minimal","status":"complete","outcome":"passed","runTime":783.119615,"created":"2026-01-20T06:30:33.616344","updated":"2026-01-20T06:30:33.616350","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0769fb17-dbba-454e-b429-45001da0072f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0769fb17-dbba-454e-b429-45001da0072f/pipeline.log\">pipeline</a>"]},{"id":"cfd0c613-78f7-4339-8f88-1107e1f1c8a8","name":"Fedora - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":743.584173,"created":"2026-01-20T06:30:34.632649","updated":"2026-01-20T06:30:34.632655","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cfd0c613-78f7-4339-8f88-1107e1f1c8a8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cfd0c613-78f7-4339-8f88-1107e1f1c8a8/pipeline.log\">pipeline</a>"]},{"id":"253deaee-07fd-445e-9529-768189520352","name":"CentOS Stream 9 - PyTest - 20","status":"complete","outcome":"passed","runTime":1030.245587,"created":"2026-01-20T06:30:35.304609","updated":"2026-01-20T06:30:35.304615","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/253deaee-07fd-445e-9529-768189520352\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/253deaee-07fd-445e-9529-768189520352/pipeline.log\">pipeline</a>"]},{"id":"1b0cdebe-c6c2-4756-8308-e832a723f2c7","name":"RHEL9 - Unsubscribed host - 22-minimal","status":"complete","outcome":"passed","runTime":1062.92665,"created":"2026-01-20T06:30:35.919007","updated":"2026-01-20T06:30:35.919015","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1b0cdebe-c6c2-4756-8308-e832a723f2c7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1b0cdebe-c6c2-4756-8308-e832a723f2c7/pipeline.log\">pipeline</a>"]},{"id":"7c5b28b6-19c0-43b5-867b-420181331f5e","name":"RHEL9 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":1140.171995,"created":"2026-01-20T06:30:33.024938","updated":"2026-01-20T06:30:33.024943","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c5b28b6-19c0-43b5-867b-420181331f5e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7c5b28b6-19c0-43b5-867b-420181331f5e/pipeline.log\">pipeline</a>"]},{"id":"da7e8ff4-b84b-45c9-ad75-da2ee1fb5897","name":"RHEL10 - Unsubscribed host - PyTest - 22","status":"complete","outcome":"passed","runTime":1177.274,"created":"2026-01-20T06:30:33.326903","updated":"2026-01-20T06:30:33.326908","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/da7e8ff4-b84b-45c9-ad75-da2ee1fb5897\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/da7e8ff4-b84b-45c9-ad75-da2ee1fb5897/pipeline.log\">pipeline</a>"]},{"id":"add082ad-1fa0-46de-91f4-932cee98d7f2","name":"RHEL10 - Unsubscribed host - PyTest - 24","status":"complete","outcome":"passed","runTime":1155.005249,"created":"2026-01-20T06:30:35.600884","updated":"2026-01-20T06:30:35.600891","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/add082ad-1fa0-46de-91f4-932cee98d7f2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/add082ad-1fa0-46de-91f4-932cee98d7f2/pipeline.log\">pipeline</a>"]},{"id":"0f448058-4881-4fa2-8821-5ff5eb8d310a","name":"RHEL9 - 24","status":"complete","outcome":"passed","runTime":1316.255255,"created":"2026-01-20T06:30:34.586157","updated":"2026-01-20T06:30:34.586163","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0f448058-4881-4fa2-8821-5ff5eb8d310a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0f448058-4881-4fa2-8821-5ff5eb8d310a/pipeline.log\">pipeline</a>"]},{"id":"aa83c8e7-9746-47c3-80e1-2c7a5af88b0a","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1268.37788,"created":"2026-01-20T06:30:35.271496","updated":"2026-01-20T06:30:35.271502","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa83c8e7-9746-47c3-80e1-2c7a5af88b0a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa83c8e7-9746-47c3-80e1-2c7a5af88b0a/pipeline.log\">pipeline</a>"]},{"id":"feacc8d5-513e-4c03-8409-8a4407045213","name":"RHEL9 - PyTest - 22","status":"complete","outcome":"passed","runTime":1559.25114,"created":"2026-01-20T06:30:34.577346","updated":"2026-01-20T06:30:34.577351","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/feacc8d5-513e-4c03-8409-8a4407045213\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/feacc8d5-513e-4c03-8409-8a4407045213/pipeline.log\">pipeline</a>"]},{"id":"de8d568b-d268-4aa6-95ef-4fcb4a5f87f2","name":"RHEL8 - 20-minimal","status":"complete","outcome":"passed","runTime":940.669095,"created":"2026-01-20T06:41:01.535692","updated":"2026-01-20T06:41:01.535699","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/de8d568b-d268-4aa6-95ef-4fcb4a5f87f2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/de8d568b-d268-4aa6-95ef-4fcb4a5f87f2/pipeline.log\">pipeline</a>"]},{"id":"66d46328-4dd6-4dda-b993-e7a54eb7dbf0","name":"RHEL10 - 24-minimal","status":"complete","outcome":"passed","runTime":810.485443,"created":"2026-01-20T06:44:55.894876","updated":"2026-01-20T06:44:55.894883","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/66d46328-4dd6-4dda-b993-e7a54eb7dbf0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/66d46328-4dd6-4dda-b993-e7a54eb7dbf0/pipeline.log\">pipeline</a>"]},{"id":"0689a7f6-b945-4ced-af20-982d935b64c0","name":"RHEL9 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":1175.56888,"created":"2026-01-20T06:38:58.750518","updated":"2026-01-20T06:38:58.750524","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0689a7f6-b945-4ced-af20-982d935b64c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0689a7f6-b945-4ced-af20-982d935b64c0/pipeline.log\">pipeline</a>"]},{"id":"cda763db-026c-4457-9910-6d8279f88fd6","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":727.694158,"created":"2026-01-20T06:50:57.301667","updated":"2026-01-20T06:50:57.301674","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cda763db-026c-4457-9910-6d8279f88fd6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cda763db-026c-4457-9910-6d8279f88fd6/pipeline.log\">pipeline</a>"]},{"id":"6794dd23-910b-45f5-bfd6-63c31bf6a335","name":"Fedora - PyTest - 24","status":"complete","outcome":"passed","runTime":844.848361,"created":"2026-01-20T06:50:47.722556","updated":"2026-01-20T06:50:47.722562","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6794dd23-910b-45f5-bfd6-63c31bf6a335\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6794dd23-910b-45f5-bfd6-63c31bf6a335/pipeline.log\">pipeline</a>"]},{"id":"18a4dd9c-2dc0-490b-bfb8-56fcf796d897","name":"RHEL8 - 22","status":"complete","outcome":"passed","runTime":988.5734,"created":"2026-01-20T06:48:56.815536","updated":"2026-01-20T06:48:56.815543","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/18a4dd9c-2dc0-490b-bfb8-56fcf796d897\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/18a4dd9c-2dc0-490b-bfb8-56fcf796d897/pipeline.log\">pipeline</a>"]},{"id":"b9abc464-e94a-4120-b347-680f1360ac24","name":"RHEL8 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1227.337133,"created":"2026-01-20T06:44:59.685937","updated":"2026-01-20T06:44:59.685943","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9abc464-e94a-4120-b347-680f1360ac24\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9abc464-e94a-4120-b347-680f1360ac24/pipeline.log\">pipeline</a>"]},{"id":"aa0da25b-f24c-4980-bbca-2cd69ff0eed4","name":"RHEL9 - Unsubscribed host - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1053.501861,"created":"2026-01-20T06:48:56.598297","updated":"2026-01-20T06:48:56.598303","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa0da25b-f24c-4980-bbca-2cd69ff0eed4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa0da25b-f24c-4980-bbca-2cd69ff0eed4/pipeline.log\">pipeline</a>"]},{"id":"190dc042-4fa8-4b43-83e1-cc4054c523ef","name":"RHEL8 - PyTest - 22","status":"complete","outcome":"passed","runTime":1255.593978,"created":"2026-01-20T06:48:58.827201","updated":"2026-01-20T06:48:58.827207","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/190dc042-4fa8-4b43-83e1-cc4054c523ef\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/190dc042-4fa8-4b43-83e1-cc4054c523ef/pipeline.log\">pipeline</a>"]},{"id":"0c77e4a2-23bf-4c04-90b1-cc5d802f5114","name":"RHEL10 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":788.84036,"created":"2026-01-20T06:56:51.891815","updated":"2026-01-20T06:56:51.891821","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c77e4a2-23bf-4c04-90b1-cc5d802f5114\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c77e4a2-23bf-4c04-90b1-cc5d802f5114/pipeline.log\">pipeline</a>"]},{"id":"f208116e-694e-42b6-9cad-719191c6cdf0","name":"RHEL8 - 22-minimal","status":"complete","outcome":"passed","runTime":1027.403532,"created":"2026-01-20T06:54:54.548004","updated":"2026-01-20T06:54:54.548011","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f208116e-694e-42b6-9cad-719191c6cdf0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f208116e-694e-42b6-9cad-719191c6cdf0/pipeline.log\">pipeline</a>"]},{"id":"98870053-80f3-4719-bb59-fbe5c5905ffc","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":939.253673,"created":"2026-01-20T06:56:59.149736","updated":"2026-01-20T06:56:59.149742","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/98870053-80f3-4719-bb59-fbe5c5905ffc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/98870053-80f3-4719-bb59-fbe5c5905ffc/pipeline.log\">pipeline</a>"]},{"id":"98355f7a-6879-4a71-ac79-a078cc87e75a","name":"RHEL10 - 24","status":"complete","outcome":"passed","runTime":922.753655,"created":"2026-01-20T06:57:22.046597","updated":"2026-01-20T06:57:22.046603","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/98355f7a-6879-4a71-ac79-a078cc87e75a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/98355f7a-6879-4a71-ac79-a078cc87e75a/pipeline.log\">pipeline</a>"]},{"id":"62b5fa2e-5fec-4ee6-bc96-7a790097d6bf","name":"RHEL9 - PyTest - 20-minimal","status":"complete","outcome":"passed","runTime":1413.679967,"created":"2026-01-20T06:52:58.881824","updated":"2026-01-20T06:52:58.881830","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/62b5fa2e-5fec-4ee6-bc96-7a790097d6bf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/62b5fa2e-5fec-4ee6-bc96-7a790097d6bf/pipeline.log\">pipeline</a>"]},{"id":"53589e11-37ba-4580-86b4-a9fb7de3b809","name":"RHEL10 - PyTest - 22","status":"complete","outcome":"passed","runTime":1236.968103,"created":"2026-01-20T06:56:51.304517","updated":"2026-01-20T06:56:51.304524","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/53589e11-37ba-4580-86b4-a9fb7de3b809\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/53589e11-37ba-4580-86b4-a9fb7de3b809/pipeline.log\">pipeline</a>"]},{"id":"4b097c1f-49cc-4702-adb4-4702b8e6b184","name":"CentOS Stream 10 - 24-minimal","status":"complete","outcome":"passed","runTime":669.864653,"created":"2026-01-20T07:07:11.775799","updated":"2026-01-20T07:07:11.775805","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4b097c1f-49cc-4702-adb4-4702b8e6b184\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4b097c1f-49cc-4702-adb4-4702b8e6b184/pipeline.log\">pipeline</a>"]},{"id":"68c7cbe7-7e62-4906-a97c-e3f978a1839f","name":"RHEL9 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":1161.936665,"created":"2026-01-20T06:59:17.530385","updated":"2026-01-20T06:59:17.530398","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/68c7cbe7-7e62-4906-a97c-e3f978a1839f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/68c7cbe7-7e62-4906-a97c-e3f978a1839f/pipeline.log\">pipeline</a>"]},{"id":"6fc81dcf-4a59-43b1-9f21-f158c9954627","name":"RHEL9 - 24-minimal","status":"complete","outcome":"passed","runTime":1175.498903,"created":"2026-01-20T06:59:19.751508","updated":"2026-01-20T06:59:19.751514","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6fc81dcf-4a59-43b1-9f21-f158c9954627\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6fc81dcf-4a59-43b1-9f21-f158c9954627/pipeline.log\">pipeline</a>"]},{"id":"6d141df6-b287-4359-b767-b1885c85af95","name":"RHEL10 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":975.380097,"created":"2026-01-20T07:49:32.564163","updated":"2026-01-20T07:49:32.564170","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d141df6-b287-4359-b767-b1885c85af95\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6d141df6-b287-4359-b767-b1885c85af95/pipeline.log\">pipeline</a>"]},{"id":"e9364669-cfe9-488a-83bf-1d3bca8b68fa","name":"CentOS Stream 9 - 20-minimal","status":"complete","outcome":"passed","runTime":663.114077,"created":"2026-01-20T07:09:13.840820","updated":"2026-01-20T07:09:13.840825","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e9364669-cfe9-488a-83bf-1d3bca8b68fa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e9364669-cfe9-488a-83bf-1d3bca8b68fa/pipeline.log\">pipeline</a>"]},{"id":"ae67d684-7234-4b56-b895-ad2f1b66939b","name":"RHEL9 - PyTest - 20","status":"complete","outcome":"passed","runTime":1481.060854,"created":"2026-01-20T06:56:59.527743","updated":"2026-01-20T06:56:59.527749","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ae67d684-7234-4b56-b895-ad2f1b66939b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ae67d684-7234-4b56-b895-ad2f1b66939b/pipeline.log\">pipeline</a>"]},{"id":"881e7176-e225-4a52-9bc6-debfc1b51be4","name":"RHEL9 - Unsubscribed host - 20-minimal","status":"complete","outcome":"passed","runTime":1080.152004,"created":"2026-01-20T07:07:18.520799","updated":"2026-01-20T07:07:18.520805","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/881e7176-e225-4a52-9bc6-debfc1b51be4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/881e7176-e225-4a52-9bc6-debfc1b51be4/pipeline.log\">pipeline</a>"]},{"id":"ccd0ad47-114f-4277-95ab-e316d960f380","name":"RHEL9 - Unsubscribed host - PyTest - 24","status":"complete","outcome":"passed","runTime":1181.395848,"created":"2026-01-20T07:07:16.112082","updated":"2026-01-20T07:07:16.112088","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ccd0ad47-114f-4277-95ab-e316d960f380\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ccd0ad47-114f-4277-95ab-e316d960f380/pipeline.log\">pipeline</a>"]},{"id":"448c253d-7266-4343-9db8-2fea523a07f8","name":"CentOS Stream 10 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":921.144411,"created":"2026-01-20T07:13:17.600816","updated":"2026-01-20T07:13:17.600822","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/448c253d-7266-4343-9db8-2fea523a07f8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/448c253d-7266-4343-9db8-2fea523a07f8/pipeline.log\">pipeline</a>"]},{"id":"1b63e62b-8d46-4322-848e-30f14b60a208","name":"CentOS Stream 10 - PyTest - 24","status":"complete","outcome":"passed","runTime":1023.353627,"created":"2026-01-20T07:11:36.218732","updated":"2026-01-20T07:11:36.218738","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1b63e62b-8d46-4322-848e-30f14b60a208\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1b63e62b-8d46-4322-848e-30f14b60a208/pipeline.log\">pipeline</a>"]},{"id":"c8094db0-4d6f-4998-97a4-028867a34d8a","name":"Fedora - PyTest - 22","status":"complete","outcome":"passed","runTime":854.179135,"created":"2026-01-20T07:13:39.470375","updated":"2026-01-20T07:13:39.470380","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c8094db0-4d6f-4998-97a4-028867a34d8a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c8094db0-4d6f-4998-97a4-028867a34d8a/pipeline.log\">pipeline</a>"]},{"id":"2ced8019-d9c4-4271-b24f-899b795181a7","name":"RHEL9 - Unsubscribed host - 20","status":"complete","outcome":"passed","runTime":1195.667007,"created":"2026-01-20T07:11:15.182744","updated":"2026-01-20T07:11:15.182750","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2ced8019-d9c4-4271-b24f-899b795181a7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2ced8019-d9c4-4271-b24f-899b795181a7/pipeline.log\">pipeline</a>"]},{"id":"c634d27a-0884-4f87-a71d-5822ab8f4f52","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1184.819203,"created":"2026-01-20T07:11:27.108787","updated":"2026-01-20T07:11:27.108794","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c634d27a-0884-4f87-a71d-5822ab8f4f52\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c634d27a-0884-4f87-a71d-5822ab8f4f52/pipeline.log\">pipeline</a>"]},{"id":"a8ed0953-82a4-4577-b7ae-9ac2f7f1e7df","name":"CentOS Stream 10 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":850.697725,"created":"2026-01-20T07:19:16.549020","updated":"2026-01-20T07:19:16.549025","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a8ed0953-82a4-4577-b7ae-9ac2f7f1e7df\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a8ed0953-82a4-4577-b7ae-9ac2f7f1e7df/pipeline.log\">pipeline</a>"]},{"id":"b00e1631-e723-4fa6-8829-86a47ae19ddd","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":1224.615024,"created":"2026-01-20T07:13:18.719328","updated":"2026-01-20T07:13:18.719334","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b00e1631-e723-4fa6-8829-86a47ae19ddd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b00e1631-e723-4fa6-8829-86a47ae19ddd/pipeline.log\">pipeline</a>"]},{"id":"696a1c5a-4289-4d8b-9285-5bb942e667dd","name":"RHEL10 - 22-minimal","status":"complete","outcome":"passed","runTime":881.041213,"created":"2026-01-20T07:19:42.290443","updated":"2026-01-20T07:19:42.290449","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/696a1c5a-4289-4d8b-9285-5bb942e667dd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/696a1c5a-4289-4d8b-9285-5bb942e667dd/pipeline.log\">pipeline</a>"]},{"id":"e49934e2-7989-4344-9c95-7cb3f86b8f87","name":"RHEL10 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1128.858338,"created":"2026-01-20T07:17:24.056412","updated":"2026-01-20T07:17:24.056418","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e49934e2-7989-4344-9c95-7cb3f86b8f87\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e49934e2-7989-4344-9c95-7cb3f86b8f87/pipeline.log\">pipeline</a>"]},{"id":"59fecf61-e064-40ff-9992-732f81ce6792","name":"RHEL10 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":894.270946,"created":"2026-01-20T07:23:25.996899","updated":"2026-01-20T07:23:25.996906","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/59fecf61-e064-40ff-9992-732f81ce6792\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/59fecf61-e064-40ff-9992-732f81ce6792/pipeline.log\">pipeline</a>"]},{"id":"18e2b009-22ea-4d9a-a064-28ae8e37b808","name":"RHEL10 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1090.72011,"created":"2026-01-20T07:19:34.256336","updated":"2026-01-20T07:19:34.256343","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/18e2b009-22ea-4d9a-a064-28ae8e37b808\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/18e2b009-22ea-4d9a-a064-28ae8e37b808/pipeline.log\">pipeline</a>"]},{"id":"740a8bd1-aaad-4dcd-9927-fbda8a37d4ed","name":"RHEL9 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1502.054246,"created":"2026-01-20T07:13:42.283586","updated":"2026-01-20T07:13:42.283592","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/740a8bd1-aaad-4dcd-9927-fbda8a37d4ed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/740a8bd1-aaad-4dcd-9927-fbda8a37d4ed/pipeline.log\">pipeline</a>"]},{"id":"eba7c31b-6012-4614-8637-42d5e53ead47","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1270.353576,"created":"2026-01-20T07:19:35.427771","updated":"2026-01-20T07:19:35.427778","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/eba7c31b-6012-4614-8637-42d5e53ead47\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/eba7c31b-6012-4614-8637-42d5e53ead47/pipeline.log\">pipeline</a>"]},{"id":"cf163324-51c8-46a9-b52c-2e97fe6fbb0e","name":"RHEL9 - Unsubscribed host - PyTest - 22","status":"complete","outcome":"passed","runTime":1182.088151,"created":"2026-01-20T07:21:37.687747","updated":"2026-01-20T07:21:37.687753","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cf163324-51c8-46a9-b52c-2e97fe6fbb0e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cf163324-51c8-46a9-b52c-2e97fe6fbb0e/pipeline.log\">pipeline</a>"]},{"id":"7b4e2b41-fcf4-4b03-a68b-573724c9bc46","name":"RHEL9 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1495.133566,"created":"2026-01-20T07:19:32.755147","updated":"2026-01-20T07:19:32.755153","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b4e2b41-fcf4-4b03-a68b-573724c9bc46\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b4e2b41-fcf4-4b03-a68b-573724c9bc46/pipeline.log\">pipeline</a>"]},{"id":"54ee0159-b8d6-47ca-bf7d-26f4d9d8ad72","name":"RHEL9 - PyTest - 24","status":"complete","outcome":"passed","runTime":1524.158996,"created":"2026-01-20T07:19:52.657665","updated":"2026-01-20T07:19:52.657671","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/54ee0159-b8d6-47ca-bf7d-26f4d9d8ad72\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/54ee0159-b8d6-47ca-bf7d-26f4d9d8ad72/pipeline.log\">pipeline</a>"]}]} -->