### PR TITLE
Nodejs minimalization.

### DIFF
--- a/24-minimal/Dockerfile.c10s
+++ b/24-minimal/Dockerfile.c10s
@@ -49,7 +49,7 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which" && \
+RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     microdnf clean all && \
     ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \


### PR DESCRIPTION
Removing `findutils tar which`, to see what breaks.
So far removing these dependencies safes about 1MB:

```
IMAGE                    ID                  DISK USAGE       CONTENT SIZE   EXTRA
app:original             e5da0ec964d8        275MB            0B        
app:lean                 f4f87d3dacbd        274MB            0B   
```

<!-- testing-farm = {"lock":"false","comment-id":"4281030038","data":[{"id":"cc5fcca5-56e4-43e0-b86c-642d0d0650b8","name":"RHEL9 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":1492.479615,"created":"2026-05-19T12:19:08.789987","updated":"2026-05-19T12:19:08.789992","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc5fcca5-56e4-43e0-b86c-642d0d0650b8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cc5fcca5-56e4-43e0-b86c-642d0d0650b8/pipeline.log\">pipeline</a>"]},{"id":"79a27144-cf7b-4b2a-8b9d-ccaeb1f368ca","name":"RHEL9 - FIPS Enabled - 20","status":"complete","outcome":"passed","runTime":2122.111153,"created":"2026-04-20T12:39:19.969198","updated":"2026-04-20T12:39:19.969209","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/79a27144-cf7b-4b2a-8b9d-ccaeb1f368ca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/79a27144-cf7b-4b2a-8b9d-ccaeb1f368ca/pipeline.log\">pipeline</a>"]},{"id":"1687a576-ad2d-4369-9aa9-76c24d1c1213","name":"RHEL10 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1139.197504,"created":"2026-05-19T12:18:24.629023","updated":"2026-05-19T12:18:24.629033","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1687a576-ad2d-4369-9aa9-76c24d1c1213\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1687a576-ad2d-4369-9aa9-76c24d1c1213/pipeline.log\">pipeline</a>"]},{"id":"29099546-a15a-42de-a757-4e6c64b8055f","name":"RHEL10 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":1183.266568,"created":"2026-05-19T12:21:25.773722","updated":"2026-05-19T12:21:25.773730","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/29099546-a15a-42de-a757-4e6c64b8055f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/29099546-a15a-42de-a757-4e6c64b8055f/pipeline.log\">pipeline</a>"]},{"id":"6e946134-e405-4256-9f26-0657b1e97ac3","name":"RHEL9 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":1705.824057,"created":"2026-05-19T12:18:15.399955","updated":"2026-05-19T12:18:15.399961","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e946134-e405-4256-9f26-0657b1e97ac3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e946134-e405-4256-9f26-0657b1e97ac3/pipeline.log\">pipeline</a>"]},{"id":"f177bd52-7726-40cd-a6de-c76fff58d212","name":"RHEL9 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":1419.541491,"created":"2026-05-19T12:23:36.903389","updated":"2026-05-19T12:23:36.903394","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f177bd52-7726-40cd-a6de-c76fff58d212\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f177bd52-7726-40cd-a6de-c76fff58d212/pipeline.log\">pipeline</a>"]},{"id":"900fe962-6a59-40d3-8ac0-0774c6d73534","name":"RHEL10 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":1335.457871,"created":"2026-05-19T12:21:32.046785","updated":"2026-05-19T12:21:32.046793","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/900fe962-6a59-40d3-8ac0-0774c6d73534\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/900fe962-6a59-40d3-8ac0-0774c6d73534/pipeline.log\">pipeline</a>"]},{"id":"2122529a-8665-4499-9087-10070ab6cf73","name":"CentOS Stream 9 - 24-minimal","status":"complete","outcome":"passed","runTime":690.268701,"created":"2026-05-19T12:26:07.478519","updated":"2026-05-19T12:26:07.478526","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2122529a-8665-4499-9087-10070ab6cf73\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2122529a-8665-4499-9087-10070ab6cf73/pipeline.log\">pipeline</a>"]},{"id":"ac23623f-f387-4a5f-888d-63244cdc9647","name":"Fedora - 24-minimal","status":"complete","outcome":"passed","runTime":513.494357,"created":"2026-05-19T12:41:54.910525","updated":"2026-05-19T12:41:54.910533","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ac23623f-f387-4a5f-888d-63244cdc9647\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ac23623f-f387-4a5f-888d-63244cdc9647/pipeline.log\">pipeline</a>"]},{"id":"2180ffe9-7730-4f6c-a583-58a611fec33e","name":"RHEL10 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":1985.529207,"created":"2026-05-19T12:15:35.137992","updated":"2026-05-19T12:15:35.138001","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2180ffe9-7730-4f6c-a583-58a611fec33e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2180ffe9-7730-4f6c-a583-58a611fec33e/pipeline.log\">pipeline</a>"]},{"id":"5b09b662-3044-4b41-afab-849c8706eaec","name":"CentOS Stream 9 - 20","status":"complete","outcome":"passed","runTime":837.216395,"created":"2026-04-20T13:45:08.453677","updated":"2026-04-20T13:45:08.453683","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5b09b662-3044-4b41-afab-849c8706eaec\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5b09b662-3044-4b41-afab-849c8706eaec/pipeline.log\">pipeline</a>"]},{"id":"0d2c408e-e1fe-4227-b44d-0f2e7cccbffc","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":879.861737,"created":"2026-05-19T12:51:39.514568","updated":"2026-05-19T12:51:39.514577","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0d2c408e-e1fe-4227-b44d-0f2e7cccbffc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0d2c408e-e1fe-4227-b44d-0f2e7cccbffc/pipeline.log\">pipeline</a>"]},{"id":"eb0b38d9-82aa-47a4-bfcc-def8ccfa072c","name":"Fedora - 24","status":"complete","outcome":"passed","runTime":579.685585,"created":"2026-05-19T12:52:20.054290","updated":"2026-05-19T12:52:20.054296","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/eb0b38d9-82aa-47a4-bfcc-def8ccfa072c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/eb0b38d9-82aa-47a4-bfcc-def8ccfa072c/pipeline.log\">pipeline</a>"]},{"id":"52641b7a-2537-4d4f-bcb3-f8ae96ab23f0","name":"RHEL9 - Unsubscribed host - 20-minimal","status":"complete","outcome":"passed","runTime":1146.258083,"created":"2026-04-20T13:47:35.765793","updated":"2026-04-20T13:47:35.765799","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/52641b7a-2537-4d4f-bcb3-f8ae96ab23f0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/52641b7a-2537-4d4f-bcb3-f8ae96ab23f0/pipeline.log\">pipeline</a>"]},{"id":"61a32efc-4edd-4824-a8e6-df43f961acfd","name":"RHEL9 - FIPS Enabled - 20-minimal","status":"complete","outcome":"passed","runTime":1879.886227,"created":"2026-04-20T13:38:18.299620","updated":"2026-04-20T13:38:18.299625","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/61a32efc-4edd-4824-a8e6-df43f961acfd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/61a32efc-4edd-4824-a8e6-df43f961acfd/pipeline.log\">pipeline</a>"]},{"id":"68d804fa-a686-43dd-96ff-0b4bf2327270","name":"RHEL9 - 20","status":"complete","outcome":"passed","runTime":1489.299987,"created":"2026-04-20T13:44:38.770196","updated":"2026-04-20T13:44:38.770204","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/68d804fa-a686-43dd-96ff-0b4bf2327270\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/68d804fa-a686-43dd-96ff-0b4bf2327270/pipeline.log\">pipeline</a>"]},{"id":"3b58536d-9a09-4afd-afaf-641d33942b97","name":"RHEL9 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":3254.861917,"created":"2026-05-19T12:21:49.293413","updated":"2026-05-19T12:21:49.293419","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3b58536d-9a09-4afd-afaf-641d33942b97\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3b58536d-9a09-4afd-afaf-641d33942b97/pipeline.log\">pipeline</a>"]},{"id":"40e400b8-1a28-4cba-9f03-8aff16b5844d","name":"RHEL8 - 20","status":"complete","outcome":"passed","runTime":1008.904056,"created":"2026-04-20T13:54:20.874311","updated":"2026-04-20T13:54:20.874319","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/40e400b8-1a28-4cba-9f03-8aff16b5844d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/40e400b8-1a28-4cba-9f03-8aff16b5844d/pipeline.log\">pipeline</a>"]},{"id":"35ca8b63-23a5-443a-9f13-cf8216e2f240","name":"RHEL10 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":1010.777943,"created":"2026-05-19T12:48:19.158508","updated":"2026-05-19T12:48:19.158517","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/35ca8b63-23a5-443a-9f13-cf8216e2f240\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/35ca8b63-23a5-443a-9f13-cf8216e2f240/pipeline.log\">pipeline</a>"]},{"id":"25fab49e-a993-4c8b-ae9b-d9be7d86da48","name":"RHEL9 - 20-minimal","status":"complete","outcome":"passed","runTime":1308.080889,"created":"2026-04-20T13:53:44.471595","updated":"2026-04-20T13:53:44.471602","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/25fab49e-a993-4c8b-ae9b-d9be7d86da48\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/25fab49e-a993-4c8b-ae9b-d9be7d86da48/pipeline.log\">pipeline</a>"]},{"id":"99c1fc73-9206-4722-9736-4ab1a284926c","name":"RHEL9 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":1281.184193,"created":"2026-05-19T12:48:57.749011","updated":"2026-05-19T12:48:57.749020","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/99c1fc73-9206-4722-9736-4ab1a284926c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/99c1fc73-9206-4722-9736-4ab1a284926c/pipeline.log\">pipeline</a>"]},{"id":"c3c76e9d-8953-4047-b9af-c7ec649e029d","name":"RHEL9 - 24","status":"complete","outcome":"passed","runTime":1342.041199,"created":"2026-05-19T12:50:20.092959","updated":"2026-05-19T12:50:20.092966","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3c76e9d-8953-4047-b9af-c7ec649e029d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3c76e9d-8953-4047-b9af-c7ec649e029d/pipeline.log\">pipeline</a>"]},{"id":"40e69451-c4b6-4a44-8fac-da2e97df56a1","name":"RHEL10 - 24","status":"complete","outcome":"passed","runTime":1526.660173,"created":"2026-05-19T12:33:38.024475","updated":"2026-05-19T12:33:38.024480","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/40e69451-c4b6-4a44-8fac-da2e97df56a1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/40e69451-c4b6-4a44-8fac-da2e97df56a1/pipeline.log\">pipeline</a>"]},{"id":"05ecc295-3395-457a-aae6-1e42de3720a7","name":"CentOS Stream 10 - 24-minimal","status":"complete","outcome":"passed","runTime":674.503314,"created":"2026-05-19T12:39:02.592848","updated":"2026-05-19T12:39:02.592854","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/05ecc295-3395-457a-aae6-1e42de3720a7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/05ecc295-3395-457a-aae6-1e42de3720a7/pipeline.log\">pipeline</a>"]},{"id":"2b82396d-04bf-442d-b905-bc48f6e493ac","name":"RHEL10 - Unsubscribed host - 22-minimal","status":"complete","outcome":"passed","runTime":1023.987775,"created":"2026-05-19T12:45:54.243994","updated":"2026-05-19T12:45:54.244004","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b82396d-04bf-442d-b905-bc48f6e493ac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b82396d-04bf-442d-b905-bc48f6e493ac/pipeline.log\">pipeline</a>"]},{"id":"942b9ab3-7e51-465f-9961-2253270d4236","name":"RHEL10 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":1647.899605,"created":"2026-05-19T12:38:43.528317","updated":"2026-05-19T12:38:43.528326","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/942b9ab3-7e51-465f-9961-2253270d4236\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/942b9ab3-7e51-465f-9961-2253270d4236/pipeline.log\">pipeline</a>"]},{"id":"71445ea5-e2af-43f4-9932-447cb0e875f0","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":1367.037262,"created":"2026-05-19T12:23:57.107195","updated":"2026-05-19T12:23:57.107202","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/71445ea5-e2af-43f4-9932-447cb0e875f0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/71445ea5-e2af-43f4-9932-447cb0e875f0/pipeline.log\">pipeline</a>"]},{"id":"c61218e3-c7b3-4972-bade-3f705156cde1","name":"CentOS Stream 10 - 24","status":"complete","outcome":"passed","runTime":793.195479,"created":"2026-05-19T12:26:56.784760","updated":"2026-05-19T12:26:56.784766","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c61218e3-c7b3-4972-bade-3f705156cde1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c61218e3-c7b3-4972-bade-3f705156cde1/pipeline.log\">pipeline</a>"]},{"id":"c1b013c7-a8dd-4beb-b690-42644904fa4d","name":"RHEL8 - 22","status":"complete","outcome":"passed","runTime":1069.339688,"created":"2026-05-19T12:28:40.093184","updated":"2026-05-19T12:28:40.093189","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c1b013c7-a8dd-4beb-b690-42644904fa4d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c1b013c7-a8dd-4beb-b690-42644904fa4d/pipeline.log\">pipeline</a>"]},{"id":"9b7e4a5f-8c70-4bb6-a67f-6892bacc0018","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":743.960901,"created":"2026-05-19T12:45:28.039201","updated":"2026-05-19T12:45:28.039209","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9b7e4a5f-8c70-4bb6-a67f-6892bacc0018\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9b7e4a5f-8c70-4bb6-a67f-6892bacc0018/pipeline.log\">pipeline</a>"]},{"id":"9cfc3f03-7c45-4941-b159-78ea683c0b1f","name":"RHEL10 - 22-minimal","status":"complete","outcome":"passed","runTime":1175.053941,"created":"2026-05-19T12:34:02.486467","updated":"2026-05-19T12:34:02.486473","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cfc3f03-7c45-4941-b159-78ea683c0b1f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cfc3f03-7c45-4941-b159-78ea683c0b1f/pipeline.log\">pipeline</a>"]},{"id":"70dc10e6-30bc-41fa-96ef-5a76cc0cef83","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":1546.899594,"created":"2026-05-19T12:29:16.925790","updated":"2026-05-19T12:29:16.925797","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/70dc10e6-30bc-41fa-96ef-5a76cc0cef83\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/70dc10e6-30bc-41fa-96ef-5a76cc0cef83/pipeline.log\">pipeline</a>"]},{"id":"45c4a4e0-731f-436c-ac5b-a4b63e1cfd67","name":"RHEL9 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":1886.053095,"created":"2026-05-19T12:25:18.769377","updated":"2026-05-19T12:25:18.769382","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/45c4a4e0-731f-436c-ac5b-a4b63e1cfd67\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/45c4a4e0-731f-436c-ac5b-a4b63e1cfd67/pipeline.log\">pipeline</a>"]},{"id":"b9775d08-0c62-436a-96dd-2e6c213e9e10","name":"RHEL10 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":1148.868177,"created":"2026-05-19T12:41:25.244827","updated":"2026-05-19T12:41:25.244833","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9775d08-0c62-436a-96dd-2e6c213e9e10\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b9775d08-0c62-436a-96dd-2e6c213e9e10/pipeline.log\">pipeline</a>"]},{"id":"ee2f90a1-0096-4fa5-b077-10317e4a2637","name":"CentOS Stream 9 - 24","status":"complete","outcome":"passed","runTime":813.317182,"created":"2026-05-19T12:48:02.158224","updated":"2026-05-19T12:48:02.158234","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ee2f90a1-0096-4fa5-b077-10317e4a2637\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ee2f90a1-0096-4fa5-b077-10317e4a2637/pipeline.log\">pipeline</a>"]},{"id":"197b9c8a-b0f6-4e02-b181-dfd1d99d3f4c","name":"RHEL9 - 24-minimal","status":"complete","outcome":"passed","runTime":1570.890752,"created":"2026-05-19T12:35:52.153486","updated":"2026-05-19T12:35:52.153492","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/197b9c8a-b0f6-4e02-b181-dfd1d99d3f4c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/197b9c8a-b0f6-4e02-b181-dfd1d99d3f4c/pipeline.log\">pipeline</a>"]},{"id":"928a657e-2a75-4a98-82ef-06ba787d547b","name":"RHEL9 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":1180.656823,"created":"2026-05-19T12:45:32.610325","updated":"2026-05-19T12:45:32.610333","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/928a657e-2a75-4a98-82ef-06ba787d547b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/928a657e-2a75-4a98-82ef-06ba787d547b/pipeline.log\">pipeline</a>"]},{"id":"d25a41a3-0cf2-4c78-b140-089c312ba272","name":"RHEL8 - 22-minimal","status":"complete","outcome":"passed","runTime":2202.442017,"created":"2026-05-19T12:29:25.259184","updated":"2026-05-19T12:29:25.259190","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d25a41a3-0cf2-4c78-b140-089c312ba272\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d25a41a3-0cf2-4c78-b140-089c312ba272/pipeline.log\">pipeline</a>"]},{"id":"ebbad559-ee2d-4506-a429-24ad73fcd16f","name":"RHEL10 - 24-minimal","status":"complete","outcome":"passed","runTime":1054.050544,"created":"2026-05-19T12:54:29.970822","updated":"2026-05-19T12:54:29.970831","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebbad559-ee2d-4506-a429-24ad73fcd16f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ebbad559-ee2d-4506-a429-24ad73fcd16f/pipeline.log\">pipeline</a>"]},{"id":"3cee2e26-318d-45f5-9d43-c8440166a555","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":2402.936864,"created":"2026-05-19T12:35:37.411681","updated":"2026-05-19T12:35:37.411687","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cee2e26-318d-45f5-9d43-c8440166a555\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cee2e26-318d-45f5-9d43-c8440166a555/pipeline.log\">pipeline</a>"]},{"id":"02d80512-5b54-4740-8802-bbb85ce92fd4","name":"RHEL9 - Unsubscribed host - 22-minimal","runTime":1879.441798,"created":"2026-05-19T12:47:00.443284","updated":"2026-05-19T12:47:00.443290","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/02d80512-5b54-4740-8802-bbb85ce92fd4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/02d80512-5b54-4740-8802-bbb85ce92fd4/pipeline.log\">pipeline</a>"]}]} -->