### PR TITLE
Add npm ci support with opt-in strict mode

### DIFF
--- a/18-minimal/s2i/bin/assemble
+++ b/18-minimal/s2i/bin/assemble
@@ -81,12 +81,32 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
-	npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		npm install
+	fi
 
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		NODE_ENV=development npm install
+	fi
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"

--- a/18-minimal/s2i/bin/assemble
+++ b/18-minimal/s2i/bin/assemble
@@ -99,7 +99,7 @@ else
 
 	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
 	echo "---> Installing dependencies with npm ci"
-	if ! npm ci; then
+	if ! NODE_ENV=development npm ci; then
 		if [ "${NPM_CI_STRICT}" == "true" ]; then
 			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
 			exit 1

--- a/18/s2i/bin/assemble
+++ b/18/s2i/bin/assemble
@@ -81,12 +81,32 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
-	npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		npm install
+	fi
 
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		NODE_ENV=development npm install
+	fi
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"

--- a/18/s2i/bin/assemble
+++ b/18/s2i/bin/assemble
@@ -99,7 +99,7 @@ else
 
 	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
 	echo "---> Installing dependencies with npm ci"
-	if ! npm ci; then
+	if ! NODE_ENV=development npm ci; then
 		if [ "${NPM_CI_STRICT}" == "true" ]; then
 			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
 			exit 1

--- a/20-minimal/s2i/bin/assemble
+++ b/20-minimal/s2i/bin/assemble
@@ -88,12 +88,32 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
-	npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		npm install
+	fi
 
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		NODE_ENV=development npm install
+	fi
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"

--- a/20-minimal/s2i/bin/assemble
+++ b/20-minimal/s2i/bin/assemble
@@ -106,7 +106,7 @@ else
 
 	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
 	echo "---> Installing dependencies with npm ci"
-	if ! npm ci; then
+	if ! NODE_ENV=development npm ci; then
 		if [ "${NPM_CI_STRICT}" == "true" ]; then
 			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
 			exit 1

--- a/20/s2i/bin/assemble
+++ b/20/s2i/bin/assemble
@@ -88,12 +88,32 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
-	npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		npm install
+	fi
 
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		NODE_ENV=development npm install
+	fi
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"

--- a/20/s2i/bin/assemble
+++ b/20/s2i/bin/assemble
@@ -106,7 +106,7 @@ else
 
 	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
 	echo "---> Installing dependencies with npm ci"
-	if ! npm ci; then
+	if ! NODE_ENV=development npm ci; then
 		if [ "${NPM_CI_STRICT}" == "true" ]; then
 			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
 			exit 1

--- a/22-minimal/README.md
+++ b/22-minimal/README.md
@@ -237,6 +237,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_TOKEN`**
        Use authentication token for a custom NPM registry mirror
 
+**`NPM_CI_STRICT`**  
+       When set to "true", a failed `npm ci` (e.g. missing or out-of-sync `package-lock.json`) causes the build to fail immediately instead of falling back to `npm install` (default: "false")
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/22-minimal/s2i/bin/assemble
+++ b/22-minimal/s2i/bin/assemble
@@ -88,12 +88,32 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
-	npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		npm install
+	fi
 
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		NODE_ENV=development npm install
+	fi
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"

--- a/22-minimal/s2i/bin/assemble
+++ b/22-minimal/s2i/bin/assemble
@@ -106,7 +106,7 @@ else
 
 	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
 	echo "---> Installing dependencies with npm ci"
-	if ! npm ci; then
+	if ! NODE_ENV=development npm ci; then
 		if [ "${NPM_CI_STRICT}" == "true" ]; then
 			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
 			exit 1

--- a/22/README.md
+++ b/22/README.md
@@ -165,6 +165,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_TOKEN`**
        Use authentication token for a custom NPM registry mirror
 
+**`NPM_CI_STRICT`**  
+       When set to "true", a failed `npm ci` (e.g. missing or out-of-sync `package-lock.json`) causes the build to fail immediately instead of falling back to `npm install` (default: "false")
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/22/s2i/bin/assemble
+++ b/22/s2i/bin/assemble
@@ -88,12 +88,32 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
-	npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		npm install
+	fi
 
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		NODE_ENV=development npm install
+	fi
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"

--- a/22/s2i/bin/assemble
+++ b/22/s2i/bin/assemble
@@ -106,7 +106,7 @@ else
 
 	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
 	echo "---> Installing dependencies with npm ci"
-	if ! npm ci; then
+	if ! NODE_ENV=development npm ci; then
 		if [ "${NPM_CI_STRICT}" == "true" ]; then
 			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
 			exit 1

--- a/24-minimal/README.md
+++ b/24-minimal/README.md
@@ -237,6 +237,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_TOKEN`**
        Use authentication token for a custom NPM registry mirror
 
+**`NPM_CI_STRICT`**  
+       When set to "true", a failed `npm ci` (e.g. missing or out-of-sync `package-lock.json`) causes the build to fail immediately instead of falling back to `npm install` (default: "false")
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/24-minimal/s2i/bin/assemble
+++ b/24-minimal/s2i/bin/assemble
@@ -88,12 +88,32 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
-	npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		npm install
+	fi
 
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		NODE_ENV=development npm install
+	fi
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"

--- a/24-minimal/s2i/bin/assemble
+++ b/24-minimal/s2i/bin/assemble
@@ -106,7 +106,7 @@ else
 
 	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
 	echo "---> Installing dependencies with npm ci"
-	if ! npm ci; then
+	if ! NODE_ENV=development npm ci; then
 		if [ "${NPM_CI_STRICT}" == "true" ]; then
 			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
 			exit 1

--- a/24/README.md
+++ b/24/README.md
@@ -165,6 +165,9 @@ Application developers can use the following environment variables to configure 
 **`NPM_TOKEN`**
        Use authentication token for a custom NPM registry mirror
 
+**`NPM_CI_STRICT`**  
+       When set to "true", a failed `npm ci` (e.g. missing or out-of-sync `package-lock.json`) causes the build to fail immediately instead of falling back to `npm install` (default: "false")
+
 One way to define a set of environment variables is to include them as key value pairs in your repo's `.s2i/environment` file.
 
 Example: DATABASE_USER=sampleUser

--- a/24/s2i/bin/assemble
+++ b/24/s2i/bin/assemble
@@ -88,12 +88,32 @@ fi
 if [ "$NODE_ENV" != "production" ]; then
 
 	echo "---> Building your Node application from source"
-	npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		npm install
+	fi
 
 else
 
 	echo "---> Installing all dependencies"
-	NODE_ENV=development npm install
+
+	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
+	echo "---> Installing dependencies with npm ci"
+	if ! npm ci; then
+		if [ "${NPM_CI_STRICT}" == "true" ]; then
+			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
+			exit 1
+		fi
+		echo "---> WARNING: npm ci failed, falling back to npm install (set NPM_CI_STRICT=true to disable this fallback)" >&2
+		NODE_ENV=development npm install
+	fi
 
 	#do not fail when there is no build script
 	echo "---> Building in production mode"

--- a/24/s2i/bin/assemble
+++ b/24/s2i/bin/assemble
@@ -106,7 +106,7 @@ else
 
 	# Prefer npm ci for reproducible installs; fall back unless NPM_CI_STRICT=true
 	echo "---> Installing dependencies with npm ci"
-	if ! npm ci; then
+	if ! NODE_ENV=development npm ci; then
 		if [ "${NPM_CI_STRICT}" == "true" ]; then
 			echo "---> ERROR: npm ci failed and NPM_CI_STRICT=true; not falling back to npm install" >&2
 			exit 1

--- a/test/run
+++ b/test/run
@@ -156,6 +156,14 @@ TEST_SET=${TESTS:-$TEST_LIST_NPM_TOKEN} ct_run_tests_from_testset "node_env_toke
 
 cleanup
 
+prepare app
+check_prep_result $? app || exit
+echo "Testing strict npm ci mode fails the build without a lockfile: s2i build -e NPM_CI_STRICT=true"
+run_s2i_build "-e NPM_CI_STRICT=true"
+evaluate_build_result $? "-should-fail-npm-ci-strict"
+
+cleanup
+
 run_s2i_build "-e NODE_ENV=development"
 evaluate_build_result $? "-e NODE_ENV=development"
 


### PR DESCRIPTION
Use `npm ci` for dependency installs so builds are reproducible (exact versions from `package-lock.json`), falling back to `npm install` when `npm ci` fails, e.g. no lockfile, or a lockfile out of sync with `package.json`, so existing apps without a committed or out of date lockfile keep building as before.

Adds `NPM_CI_STRICT` (default: `false`). When set to `true`, a failed `npm ci` fails the build immediately instead of silently falling back to `npm install`, for users who want CI/CD pipelines to catch a broken/missing lockfile rather than silently drift to `npm install`.

Applies to all supported Node versions.

This is a replacement to an old PR: #236 that never made it in.
Prior discussion in #212 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependency installation now prefers deterministic `npm ci` over `npm install`.
  * Added optional strict mode: when `NPM_CI_STRICT=true`, build fails immediately if `npm ci` fails.
  * In default (non-strict) mode, builds log a warning and fall back to `npm install` if `npm ci` fails.
* **Documentation**
  * Updated README(s) to describe `NPM_CI_STRICT` and its default (`false`) behavior.
* **Tests**
  * Added a strict-mode S2I build check to confirm failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->