### PR TITLE
Dist git corrections

### DIFF
--- a/22-minimal/Dockerfile.c10s
+++ b/22-minimal/Dockerfile.c10s
@@ -1,4 +1,4 @@
-FROM quay.io/sclorg/s2i-core-c10s:c10s
+FROM quay.io/centos/centos:stream10-minimal
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,18 +48,14 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
-\
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which" && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     rm -f /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
     rm -f /usr/bin/npm && ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
     rm -f /usr/bin/npx && ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-\
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -67,7 +63,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/22-minimal/Dockerfile.c9s
+++ b/22-minimal/Dockerfile.c9s
@@ -1,4 +1,4 @@
-FROM quay.io/sclorg/s2i-core-c9s:c9s
+FROM quay.io/centos/centos:stream9-minimal
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,17 +48,13 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which nss_wrapper-libs" && \
-\
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-dnf -y module disable nodejs && \
-dnf -y module enable nodejs:$NODEJS_VERSION && \
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which" && \
+microdnf -y module disable nodejs && \
+microdnf -y module enable nodejs:$NODEJS_VERSION && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-     (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -66,7 +62,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/22-minimal/Dockerfile.fedora
+++ b/22-minimal/Dockerfile.fedora
@@ -49,7 +49,7 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
+RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
 \
     rm -f /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \

--- a/22-minimal/Dockerfile.rhel10
+++ b/22-minimal/Dockerfile.rhel10
@@ -1,4 +1,4 @@
-FROM ubi10/s2i-core:latest
+FROM ubi10/ubi-minimal:latest
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,18 +48,14 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
-\
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which" && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     rm -f /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
     rm -f /usr/bin/npm && ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
     rm -f /usr/bin/npx && ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-\
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -67,7 +63,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/22-minimal/Dockerfile.rhel8
+++ b/22-minimal/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM ubi8/s2i-core:latest
+FROM ubi8/ubi-minimal:latest
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,17 +48,13 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which nss_wrapper-libs" && \
-\
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-dnf -y module disable nodejs && \
-dnf -y module enable nodejs:$NODEJS_VERSION && \
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which" && \
+microdnf -y module disable nodejs && \
+microdnf -y module enable nodejs:$NODEJS_VERSION && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-     (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -66,7 +62,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/22-minimal/Dockerfile.rhel9
+++ b/22-minimal/Dockerfile.rhel9
@@ -1,4 +1,4 @@
-FROM ubi9/s2i-core:latest
+FROM ubi9/ubi-minimal:latest
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,17 +48,13 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which nss_wrapper-libs" && \
-\
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-dnf -y module disable nodejs && \
-dnf -y module enable nodejs:$NODEJS_VERSION && \
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which" && \
+microdnf -y module disable nodejs && \
+microdnf -y module enable nodejs:$NODEJS_VERSION && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-     (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -66,7 +62,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/22/Dockerfile.c10s
+++ b/22/Dockerfile.c10s
@@ -46,11 +46,8 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> sclorg/$NAME-$NODEJS_VERSION-c10s <APP-NAME>"
 
-RUN \
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
+RUN INSTALL_PKGS="make gcc gcc-c++ git openssl-devel nodejs nodejs-nodemon nodejs-npm nss_wrapper-libs which" && \
 \
-    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
-    INSTALL_PKGS="$MODULE_DEPS nodejs nodejs-nodemon nodejs-npm nss_wrapper-libs which" && \
 dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
 \

--- a/22/Dockerfile.c9s
+++ b/22/Dockerfile.c9s
@@ -46,17 +46,15 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> sclorg/$NAME-$NODEJS_VERSION-c9s <APP-NAME>"
 
-RUN \
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-    dnf -y module enable nodejs:$NODEJS_VERSION &&\
-\
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
+RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
+    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper-libs which" && \
-dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
 \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
 \
+\
+dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
 \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
      (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\

--- a/22/Dockerfile.fedora
+++ b/22/Dockerfile.fedora
@@ -46,11 +46,8 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> quay.io/fedora/$NAME-$NODEJS_VERSION:latest <APP-NAME>"
 
-RUN \
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
+RUN INSTALL_PKGS="make gcc gcc-c++ libatomic_ops git openssl-devel nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
 \
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
-    INSTALL_PKGS="$MODULE_DEPS nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
 dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
 \

--- a/22/Dockerfile.rhel10
+++ b/22/Dockerfile.rhel10
@@ -46,11 +46,8 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> ubi10/$NAME-$NODEJS_VERSION <APP-NAME>"
 
-RUN \
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
+RUN INSTALL_PKGS="make gcc gcc-c++ git openssl-devel nodejs nodejs-nodemon nodejs-npm nss_wrapper-libs which" && \
 \
-    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
-    INSTALL_PKGS="$MODULE_DEPS nodejs nodejs-nodemon nodejs-npm nss_wrapper-libs which" && \
 dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
 \

--- a/22/Dockerfile.rhel8
+++ b/22/Dockerfile.rhel8
@@ -46,17 +46,15 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> ubi8/$NAME-$NODEJS_VERSION <APP-NAME>"
 
-RUN \
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-    dnf -y module enable nodejs:$NODEJS_VERSION &&\
-\
+RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
     MODULE_DEPS="make gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-runtime libatomic_ops git openssl-devel python3.12" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper-libs which" && \
-dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
 \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
 \
+\
+dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
 \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
      (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\

--- a/22/Dockerfile.rhel9
+++ b/22/Dockerfile.rhel9
@@ -46,17 +46,15 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> ubi9/$NAME-$NODEJS_VERSION <APP-NAME>"
 
-RUN \
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-    dnf -y module enable nodejs:$NODEJS_VERSION &&\
-\
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
+RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
+    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper-libs which" && \
-dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
 \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
 \
+\
+dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
 \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
      (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\

--- a/24-minimal/Dockerfile.c10s
+++ b/24-minimal/Dockerfile.c10s
@@ -1,4 +1,4 @@
-FROM quay.io/sclorg/s2i-core-c10s:c10s
+FROM quay.io/centos/centos:stream10-minimal
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,18 +48,14 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
-\
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which" && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     rm -f /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
     rm -f /usr/bin/npm && ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
     rm -f /usr/bin/npx && ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-\
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -67,7 +63,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/24-minimal/Dockerfile.c9s
+++ b/24-minimal/Dockerfile.c9s
@@ -1,4 +1,4 @@
-FROM quay.io/sclorg/s2i-core-c9s:c9s
+FROM quay.io/centos/centos:stream9-minimal
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,17 +48,13 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which nss_wrapper-libs" && \
-\
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-dnf -y module disable nodejs && \
-dnf -y module enable nodejs:$NODEJS_VERSION && \
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which" && \
+microdnf -y module disable nodejs && \
+microdnf -y module enable nodejs:$NODEJS_VERSION && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-     (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -66,7 +62,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/24-minimal/Dockerfile.fedora
+++ b/24-minimal/Dockerfile.fedora
@@ -49,7 +49,7 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
+RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which" && \
     microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
 \
     rm -f /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \

--- a/24-minimal/Dockerfile.rhel10
+++ b/24-minimal/Dockerfile.rhel10
@@ -1,4 +1,4 @@
-FROM ubi10/s2i-core:latest
+FROM ubi10/ubi-minimal:latest
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,18 +48,14 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs" && \
-\
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which" && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     rm -f /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
     rm -f /usr/bin/npm && ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
     rm -f /usr/bin/npx && ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-\
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -67,7 +63,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/24-minimal/Dockerfile.rhel8
+++ b/24-minimal/Dockerfile.rhel8
@@ -1,4 +1,4 @@
-FROM ubi8/s2i-core:latest
+FROM ubi8/ubi-minimal:latest
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,17 +48,13 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which nss_wrapper-libs" && \
-\
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-dnf -y module disable nodejs && \
-dnf -y module enable nodejs:$NODEJS_VERSION && \
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which" && \
+microdnf -y module disable nodejs && \
+microdnf -y module enable nodejs:$NODEJS_VERSION && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-     (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -66,7 +62,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/24-minimal/Dockerfile.rhel9
+++ b/24-minimal/Dockerfile.rhel9
@@ -1,4 +1,4 @@
-FROM ubi9/s2i-core:latest
+FROM ubi9/ubi-minimal:latest
 EXPOSE 8080
 
 # Add $HOME/node_modules/.bin to the $PATH, allowing user to make npm scripts
@@ -48,17 +48,13 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container"
 
 # nodejs-full-i18n is included for error strings
-RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which nss_wrapper-libs" && \
-\
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-dnf -y module disable nodejs && \
-dnf -y module enable nodejs:$NODEJS_VERSION && \
-\
-dnf -y --nodocs --setopt=tsflags=nodocs install $INSTALL_PKGS && \
-\
+RUN INSTALL_PKGS="nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which" && \
+microdnf -y module disable nodejs && \
+microdnf -y module enable nodejs:$NODEJS_VERSION && \
+microdnf -y --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-     (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\
-    dnf clean all --enablerepo='*'
+microdnf clean all && \
+    rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*
 COPY ./s2i/bin/ /usr/libexec/s2i
 RUN chmod +x /usr/libexec/s2i/init-wrapper
 
@@ -66,7 +62,6 @@ RUN chmod +x /usr/libexec/s2i/init-wrapper
 COPY ./root/ /
 
 # Drop the root user and make the content of /opt/app-root owned by user 1001
-RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT" && \
-    rpm-file-permissions
+RUN mkdir -p "$HOME" && chown -R 1001:0 "$APP_ROOT" && chmod -R ug+rwx "$APP_ROOT"
 WORKDIR "$HOME"
 USER 1001

--- a/24/Dockerfile.c10s
+++ b/24/Dockerfile.c10s
@@ -46,11 +46,8 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> sclorg/$NAME-$NODEJS_VERSION-c10s <APP-NAME>"
 
-RUN \
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
+RUN INSTALL_PKGS="make gcc gcc-c++ git openssl-devel nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
 \
-    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
-    INSTALL_PKGS="$MODULE_DEPS nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
 dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
 \

--- a/24/Dockerfile.c9s
+++ b/24/Dockerfile.c9s
@@ -46,17 +46,15 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> sclorg/$NAME-$NODEJS_VERSION-c9s <APP-NAME>"
 
-RUN \
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-    dnf -y module enable nodejs:$NODEJS_VERSION &&\
-\
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
+RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
+    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper-libs which" && \
-dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
 \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
 \
+\
+dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
 \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
      (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\

--- a/24/Dockerfile.fedora
+++ b/24/Dockerfile.fedora
@@ -46,11 +46,8 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> quay.io/fedora/$NAME-$NODEJS_VERSION:latest <APP-NAME>"
 
-RUN \
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
+RUN INSTALL_PKGS="make gcc gcc-c++ libatomic_ops git openssl-devel nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
 \
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
-    INSTALL_PKGS="$MODULE_DEPS nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
 dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
 \

--- a/24/Dockerfile.rhel10
+++ b/24/Dockerfile.rhel10
@@ -46,11 +46,8 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> ubi10/$NAME-$NODEJS_VERSION <APP-NAME>"
 
-RUN \
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
+RUN INSTALL_PKGS="make gcc gcc-c++ git openssl-devel nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
 \
-    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
-    INSTALL_PKGS="$MODULE_DEPS nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which" && \
 dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
 \

--- a/24/Dockerfile.rhel8
+++ b/24/Dockerfile.rhel8
@@ -46,17 +46,15 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> ubi8/$NAME-$NODEJS_VERSION <APP-NAME>"
 
-RUN \
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-    dnf -y module enable nodejs:$NODEJS_VERSION &&\
-\
+RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
     MODULE_DEPS="make gcc-toolset-13-gcc gcc-toolset-13-gcc-c++ gcc-toolset-13-runtime libatomic_ops git openssl-devel python3.12" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper-libs which" && \
-dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
 \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
 \
+\
+dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
 \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
      (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\

--- a/24/Dockerfile.rhel9
+++ b/24/Dockerfile.rhel9
@@ -46,17 +46,15 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> ubi9/$NAME-$NODEJS_VERSION <APP-NAME>"
 
-RUN \
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-    dnf -y module enable nodejs:$NODEJS_VERSION &&\
-\
-    MODULE_DEPS="make gcc gcc-c++ libatomic_ops git openssl-devel" && \
+RUN dnf -y module enable nodejs:$NODEJS_VERSION && \
+    MODULE_DEPS="make gcc gcc-c++ git openssl-devel" && \
     INSTALL_PKGS="$MODULE_DEPS nodejs npm nodejs-nodemon nss_wrapper-libs which" && \
-dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
-    rpm -V $INSTALL_PKGS && \
 \
     ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
 \
+\
+dnf install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
 \
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
      (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -120,8 +120,10 @@ specs:
       build_deps: >-
         {% if spec.prod == 'fedora' -%}
           make gcc gcc-c++ libatomic_ops git openssl-devel
-        {%- elif spec.prod in ['rhel8', 'rhel9', 'c9s'] -%}
+        {%- elif spec.prod == 'rhel8' -%}
           make gcc gcc-c++ libatomic_ops git openssl-devel
+        {%- elif spec.prod in ['rhel9', 'c9s'] -%}
+          make gcc gcc-c++ git openssl-devel
         {%- else -%}
           make gcc gcc-c++ git openssl-devel
         {%- endif %}
@@ -150,7 +152,7 @@ specs:
         {%- elif spec.prod == 'fedora' -%}
           make gcc gcc-c++ libatomic_ops git openssl-devel
         {%- elif spec.prod in ['rhel9', 'c9s'] -%}
-          make gcc gcc-c++ libatomic_ops git openssl-devel
+          make gcc gcc-c++ git openssl-devel
         {%- else -%}
           make gcc gcc-c++ git openssl-devel
         {%- endif %}
@@ -177,7 +179,7 @@ specs:
         {%- elif spec.prod == 'fedora' -%}
           make gcc gcc-c++ libatomic_ops git openssl-devel
         {%- elif spec.prod in ['rhel9', 'c9s'] -%}
-          make gcc gcc-c++ libatomic_ops git openssl-devel
+          make gcc gcc-c++ git openssl-devel
         {%- else -%}
           make gcc gcc-c++ git openssl-devel
         {%- endif %}

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -14,7 +14,6 @@ specs:
       redhat_component: "${NAME}-${NODEJS_VERSION}-container"
       img_name: "fedora/$NAME-$NODEJS_VERSION"
       img_name_minimal: "fedora/$NAME-$NODEJS_VERSION-minimal"
-      pkg_manager: "dnf"
       latest_fedora: "43"
       needs_versioned_links: true
       # Modern: Fedora uses versioned packages (nodejs$VERSION), not modules
@@ -23,65 +22,58 @@ specs:
       distros:
         - rhel-8-x86_64
       s2i_base: ubi8/s2i-core
-      s2i_minimal_base: ubi8/s2i-core
+      s2i_minimal_base: ubi8/ubi-minimal
       org: "ubi8"
       prod: "rhel8"
       redhat_component: "${NAME}-${NODEJS_VERSION}-container"
       img_name: "ubi8/$NAME-$NODEJS_VERSION"
       img_name_minimal: "ubi8/$NAME-$NODEJS_VERSION-minimal"
-      pkg_manager: "dnf"
       uses_yum_for_v20: true
       needs_python3_link: true
       uses_dnf_modules: true  # Legacy: RHEL8 uses deprecated DNF modules
-      environment_setup: >-
-        dnf -y module enable nodejs:$NODEJS_VERSION &&
+      environment_setup: "dnf -y module enable nodejs:$NODEJS_VERSION && \\"
       post_install: >4-
            (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\
     rhel9:
       distros:
         - rhel-9-x86_64
       s2i_base: ubi9/s2i-core
-      s2i_minimal_base: ubi9/s2i-core
+      s2i_minimal_base: ubi9/ubi-minimal
       org: "ubi9"
       prod: "rhel9"
       redhat_component: "${NAME}-${NODEJS_VERSION}-container"
       img_name: "ubi9/$NAME-$NODEJS_VERSION"
       img_name_minimal: "ubi9/$NAME-$NODEJS_VERSION-minimal"
-      pkg_manager: "dnf"
       uses_yum_for_v20: true
       uses_dnf_modules: true  # Legacy: RHEL9 uses deprecated DNF modules
-      environment_setup: >-
-        dnf -y module enable nodejs:$NODEJS_VERSION &&
+      environment_setup: "dnf -y module enable nodejs:$NODEJS_VERSION && \\"
       post_install: >4-
            (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\
     rhel10:
       distros:
         - rhel-10-x86_64
       s2i_base: ubi10/s2i-core
-      s2i_minimal_base: ubi10/s2i-core
+      s2i_minimal_base: ubi10/ubi-minimal
       org: "ubi10"
       prod: "rhel10"
       redhat_component: "${NAME}-${NODEJS_VERSION}-container"
       img_name: "ubi10/$NAME-$NODEJS_VERSION"
       img_name_minimal: "ubi10/$NAME-$NODEJS_VERSION-minimal"
-      pkg_manager: "dnf"
       needs_versioned_links: true
       # Modern: RHEL10 uses versioned packages (nodejs$VERSION), not modules
     c9s:
       distros:
         - centos-stream-9-x86_64
       s2i_base: quay.io/sclorg/s2i-core-c9s:c9s
-      s2i_minimal_base: quay.io/sclorg/s2i-core-c9s:c9s
+      s2i_minimal_base: quay.io/centos/centos:stream9-minimal
       org: "c9s"
       prod: "c9s"
       redhat_component: "${NAME}-${NODEJS_VERSION}-container"
       img_name: "sclorg/$NAME-$NODEJS_VERSION-c9s"
       img_name_minimal: "sclorg/$NAME-$NODEJS_VERSION-minimal-c9s"
-      pkg_manager: "dnf"
       uses_yum_for_v20: true
       uses_dnf_modules: true  # Legacy: CentOS Stream 9 uses deprecated DNF modules
-      environment_setup: >-
-        dnf -y module enable nodejs:$NODEJS_VERSION &&
+      environment_setup: "dnf -y module enable nodejs:$NODEJS_VERSION && \\"
       post_install: >4-
            (dnf -y reinstall tzdata || dnf -y update tzdata ) &&\
 
@@ -89,13 +81,12 @@ specs:
       distros:
         - centos-stream-10-x86_64
       s2i_base: quay.io/sclorg/s2i-core-c10s:c10s
-      s2i_minimal_base: quay.io/sclorg/s2i-core-c10s:c10s
+      s2i_minimal_base: quay.io/centos/centos:stream10-minimal
       org: "c10s"
       prod: "c10s"
       redhat_component: "${NAME}-${NODEJS_VERSION}-container"
       img_name: "sclorg/$NAME-$NODEJS_VERSION-c10s"
       img_name_minimal: "sclorg/$NAME-$NODEJS_VERSION-minimal-c10s"
-      pkg_manager: "dnf"
       needs_versioned_links: true
       # Modern: CentOS Stream 10 uses versioned packages (nodejs$VERSION), not modules
       check_pkgs: "nodejs npm nodejs-nodemon nss_wrapper-libs which"
@@ -111,6 +102,7 @@ specs:
       rhel8_base: "ubi8/s2i-core:latest"
       rhel9_base: "ubi9/s2i-core:latest"
       fedora_base: "quay.io/fedora/s2i-core:44"
+      pkg_manager: "dnf"
       pkgs: >-
         {% if spec.prod == 'fedora' -%}
           nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which
@@ -138,6 +130,7 @@ specs:
       rhel_image_name: "rhel9/nodejs-{{ spec.short }}"
       latest_fedora: "f45"
       fedora_base: "quay.io/fedora/s2i-core:44"
+      pkg_manager: "dnf"
       pkgs: >-
         {% if spec.prod == 'fedora' -%}
           nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which
@@ -167,6 +160,7 @@ specs:
       rhel_image_name: "rhel9/nodejs-{{ spec.short }}"
       latest_fedora: "f45"
       fedora_base: "quay.io/fedora/s2i-core:44"
+      pkg_manager: "dnf"
       pkgs: >-
         {% if spec.prod in ['rhel10', 'c10s', 'fedora'] -%}
           nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-npm nss_wrapper-libs which
@@ -191,11 +185,12 @@ specs:
       rhel_image_name: "rhel8/nodejs-{{ spec.short }}"
       latest_fedora: "f45"
       fedora_minimal_base: "quay.io/fedora/fedora-minimal:44"
+      pkg_manager: "microdnf"
       minimal_pkgs: >-
         {% if spec.prod == 'fedora' -%}
-          nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs
+          nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which
         {%- else -%}
-          nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which nss_wrapper-libs
+          nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which
         {%- endif %}
       pkgs: >-
         {% if spec.prod == 'fedora' -%}
@@ -220,13 +215,14 @@ specs:
       rhel_image_name: "rhel9/nodejs-{{ spec.short }}"
       latest_fedora: "f45"
       fedora_minimal_base: "quay.io/fedora/fedora-minimal:44"
+      pkg_manager: "microdnf"
       minimal_pkgs: >-
         {% if spec.prod == 'fedora' -%}
-          nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs
+          nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which
         {%- elif spec.prod in ['rhel10', 'c10s'] -%}
-          nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs
+          nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which
         {%- else -%}
-          nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which nss_wrapper-libs
+          nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which
         {%- endif %}
       pkgs: >-
         {% if spec.prod == 'fedora' -%}
@@ -255,11 +251,12 @@ specs:
       rhel_image_name: "rhel9/nodejs-{{ spec.short }}"
       latest_fedora: "f45"
       fedora_minimal_base: "quay.io/fedora/fedora-minimal:44"
+      pkg_manager: "microdnf"
       minimal_pkgs: >-
         {% if spec.prod in ['rhel10', 'c10s', 'fedora'] -%}
-          nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which nss_wrapper-libs
+          nodejs$NODEJS_VERSION nodejs-nodemon nodejs$NODEJS_VERSION-full-i18n nodejs$NODEJS_VERSION-npm findutils tar which
         {%- else -%}
-          nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which nss_wrapper-libs
+          nodejs nodejs-nodemon nodejs-full-i18n npm findutils tar which
         {%- endif %}
       pkgs: >-
         {% if spec.prod in ['rhel10', 'c10s', 'fedora'] -%}

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -47,25 +47,23 @@ LABEL summary="$SUMMARY" \
       help="For more information visit https://github.com/sclorg/s2i-nodejs-container" \
       usage="s2i build <SOURCE-REPOSITORY> {{ spec.full_image_name | default(spec.img_name) }} <APP-NAME>"
 
-RUN {% if spec.uses_dnf_modules %}\
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-    {{ spec.environment_setup }}\
-{% else %}\
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
-{% endif %}\
+RUN {% if spec.uses_dnf_modules %}{{ spec.environment_setup }}
     MODULE_DEPS="{{ spec.build_deps }}" && \
     INSTALL_PKGS="$MODULE_DEPS {{ spec.pkgs }}" && \
+{% else %}INSTALL_PKGS="{{ spec.build_deps }} {{ spec.pkgs }}" && \
+{% endif %}
+{% if not spec.needs_versioned_links %}\
+    ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
+{% if spec.needs_python3_link and spec.version == "20" %}\
+    ln -s /usr/libexec/platform-python /usr/bin/python3 && \
+{% endif %}\
+{% endif %}\
     {% if spec.uses_yum_for_v20 and spec.version == "20" %}yum{% else %}{{ spec.pkg_manager | default("dnf") }}{% endif %} install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
 {% if spec.needs_versioned_links %}\
     rm -f /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
     rm -f /usr/bin/npm && ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
     rm -f /usr/bin/npx && ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-{% else %}\
-    ln -s /usr/lib/node_modules/nodemon/bin/nodemon.js /usr/bin/nodemon && \
-{% if spec.needs_python3_link and spec.version == "20" %}\
-    ln -s /usr/libexec/platform-python /usr/bin/python3 && \
-{% endif %}\
 {% endif %}\
     node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
 {% if spec.post_install %}    {{ spec.post_install }}

--- a/src/Dockerfile.minimal
+++ b/src/Dockerfile.minimal
@@ -50,22 +50,14 @@ LABEL summary="$SUMMARY" \
 
 # nodejs-full-i18n is included for error strings
 RUN INSTALL_PKGS="{{ spec.minimal_pkgs }}" && \
-{% if spec.uses_dnf_modules %}\
-    # Legacy RHEL8/9 and CentOS Stream 9: use deprecated DNF modules
-    {% if spec.pkg_manager | default("dnf") == "microdnf" %}microdnf{% else %}{{ spec.pkg_manager | default("dnf") }}{% endif %} -y module disable nodejs && \
+{% if spec.uses_dnf_modules %}{% if spec.pkg_manager | default("dnf") == "microdnf" %}microdnf{% else %}{{ spec.pkg_manager | default("dnf") }}{% endif %} -y module disable nodejs && \
     {% if spec.pkg_manager | default("dnf") == "microdnf" %}microdnf{% else %}{{ spec.pkg_manager | default("dnf") }}{% endif %} -y module enable nodejs:$NODEJS_VERSION && \
-{% else %}\
-    # Modern distros (Fedora, RHEL10+, CentOS Stream 10+): use versioned packages
-{% endif %}\
-    {% if spec.pkg_manager | default("dnf") == "microdnf" %}microdnf{% else %}{{ spec.pkg_manager | default("dnf") }}{% endif %} -y --nodocs {% if spec.pkg_manager | default("dnf") == "microdnf" %}--setopt=install_weak_deps=0{% else %}--setopt=tsflags=nodocs{% endif %} install $INSTALL_PKGS && \
-{% if spec.needs_versioned_links %}\
-    rm -f /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
+{% endif %}{% if spec.pkg_manager | default("dnf") == "microdnf" %}microdnf{% else %}{{ spec.pkg_manager | default("dnf") }}{% endif %} -y --nodocs {% if spec.pkg_manager | default("dnf") == "microdnf" %}--setopt=install_weak_deps=0{% else %}--setopt=tsflags=nodocs{% endif %} install $INSTALL_PKGS && \
+{% if spec.needs_versioned_links %}    rm -f /usr/bin/node && ln -s /usr/bin/node-$NODEJS_VERSION /usr/bin/node && \
     rm -f /usr/bin/npm && ln -s /usr/bin/npm-$NODEJS_VERSION /usr/bin/npm && \
     rm -f /usr/bin/npx && ln -s /usr/bin/npx-$NODEJS_VERSION /usr/bin/npx && \
-{% endif %}\
-    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
-{% if spec.post_install %}    {{ spec.post_install }}
-{% endif %}    {% if spec.pkg_manager | default("dnf") == "microdnf" %}microdnf{% else %}{{ spec.pkg_manager | default("dnf") }}{% endif %} clean all{% if spec.pkg_manager | default("dnf") != "microdnf" %} --enablerepo='*'{% endif %}{% if spec.pkg_manager | default("dnf") == "microdnf" %} && \
+{% endif %}    node -v | grep -qe "^v$NODEJS_VERSION\." && echo "Found VERSION $NODEJS_VERSION" && \
+    {% if spec.pkg_manager | default("dnf") == "microdnf" %}microdnf{% else %}{{ spec.pkg_manager | default("dnf") }}{% endif %} clean all{% if spec.pkg_manager | default("dnf") != "microdnf" %} --enablerepo='*'{% endif %}{% if spec.pkg_manager | default("dnf") == "microdnf" %} && \
     rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/dnf* /mnt/rootfs/var/log/yum.*{% endif %}
 
 COPY ./s2i/bin/ /usr/libexec/s2i


### PR DESCRIPTION
There were issues with RHEL9 and 8 around command order as well as microdnf not being used in minimal images.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Minimal Node.js images now use distribution-provided minimal base images.
  * Package installation and cleanup are streamlined across supported distributions, reducing optional packages and retained cache files.
  * Standard and minimal builds now use package-management configuration appropriate to each environment.
  * Dockerfile build steps, Node.js command linking, and version verification are more consistent across supported versions and platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"5584934734","data":[{"id":"995f9827-f90f-42ad-817a-ce10d58fbd40","name":"Fedora - PyTest - 22","status":"complete","outcome":"passed","runTime":1096.558462,"created":"2026-09-14T11:50:46.240704","updated":"2026-09-14T11:50:46.240713","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/995f9827-f90f-42ad-817a-ce10d58fbd40\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/995f9827-f90f-42ad-817a-ce10d58fbd40/pipeline.log\">pipeline</a>"]},{"id":"e07d1fd8-c7de-463f-a289-4b973b3a7c0f","name":"CentOS Stream 10 - 22","status":"complete","outcome":"passed","runTime":919.144151,"created":"2026-09-14T09:47:22.059312","updated":"2026-09-14T09:47:22.059320","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e07d1fd8-c7de-463f-a289-4b973b3a7c0f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e07d1fd8-c7de-463f-a289-4b973b3a7c0f/pipeline.log\">pipeline</a>"]},{"id":"e2c15e7c-5859-44f0-9613-c00d5698e7af","name":"RHEL10 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":5839.399134,"created":"2026-09-14T09:47:23.273252","updated":"2026-09-14T09:47:23.273260","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e2c15e7c-5859-44f0-9613-c00d5698e7af\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e2c15e7c-5859-44f0-9613-c00d5698e7af/pipeline.log\">pipeline</a>"]},{"id":"af7a6860-0d1f-4361-b332-b56b7b72965d","name":"RHEL10 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":5567.805528,"created":"2026-09-14T09:47:05.700618","updated":"2026-09-14T09:47:05.700625","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/af7a6860-0d1f-4361-b332-b56b7b72965d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/af7a6860-0d1f-4361-b332-b56b7b72965d/pipeline.log\">pipeline</a>"]},{"id":"87c4b05f-840b-4915-8355-6b07d159416c","name":"RHEL10 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":5857.623823,"created":"2026-09-14T09:47:05.874705","updated":"2026-09-14T09:47:05.874712","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/87c4b05f-840b-4915-8355-6b07d159416c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/87c4b05f-840b-4915-8355-6b07d159416c/pipeline.log\">pipeline</a>"]},{"id":"5ccdc6af-577a-4a34-baba-ef0d82087f0e","name":"RHEL9 - 22","status":"complete","outcome":"passed","runTime":2600.031811,"created":"2026-09-14T11:22:15.509910","updated":"2026-09-14T11:22:15.509917","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ccdc6af-577a-4a34-baba-ef0d82087f0e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5ccdc6af-577a-4a34-baba-ef0d82087f0e/pipeline.log\">pipeline</a>"]},{"id":"2acaddb8-f235-4709-8242-21b15af71921","name":"CentOS Stream 9 - 24","status":"complete","outcome":"passed","runTime":958.929549,"created":"2026-09-14T11:29:21.518971","updated":"2026-09-14T11:29:21.518981","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2acaddb8-f235-4709-8242-21b15af71921\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2acaddb8-f235-4709-8242-21b15af71921/pipeline.log\">pipeline</a>"]},{"id":"6800ef6e-38f9-40f9-96d1-fa9bd0a96ecb","name":"RHEL10 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":1521.469028,"created":"2026-09-14T11:26:09.964450","updated":"2026-09-14T11:26:09.964456","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6800ef6e-38f9-40f9-96d1-fa9bd0a96ecb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6800ef6e-38f9-40f9-96d1-fa9bd0a96ecb/pipeline.log\">pipeline</a>"]},{"id":"6013ec5e-0732-457b-9960-08ce3dd96af9","name":"RHEL10 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":5678.6318,"created":"2026-09-14T09:47:07.589186","updated":"2026-09-14T09:47:07.589194","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6013ec5e-0732-457b-9960-08ce3dd96af9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6013ec5e-0732-457b-9960-08ce3dd96af9/pipeline.log\">pipeline</a>"]},{"id":"b8b9998e-95e0-4719-8889-214215efe071","name":"CentOS Stream 9 - PyTest - 22","status":"complete","outcome":"passed","runTime":1341.135855,"created":"2026-09-14T12:21:51.199719","updated":"2026-09-14T12:21:51.199726","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b8b9998e-95e0-4719-8889-214215efe071\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b8b9998e-95e0-4719-8889-214215efe071/pipeline.log\">pipeline</a>"]},{"id":"60dd081c-9c2c-4b42-9393-d760759bb26d","name":"RHEL10 - Unsubscribed host - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1662.929233,"created":"2026-09-14T12:19:39.619833","updated":"2026-09-14T12:19:39.619841","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/60dd081c-9c2c-4b42-9393-d760759bb26d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/60dd081c-9c2c-4b42-9393-d760759bb26d/pipeline.log\">pipeline</a>"]},{"id":"6ef96c24-9a57-43f4-8f1e-841525528198","name":"RHEL8 - 24","status":"complete","outcome":"passed","runTime":5188.533522,"created":"2026-09-14T09:47:23.479497","updated":"2026-09-14T09:47:23.479505","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ef96c24-9a57-43f4-8f1e-841525528198\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ef96c24-9a57-43f4-8f1e-841525528198/pipeline.log\">pipeline</a>"]},{"id":"1abdd79a-fa9b-4829-aba2-7017cd16ed75","name":"RHEL10 - 22-minimal","status":"complete","outcome":"passed","runTime":1462.11886,"created":"2026-09-09T12:50:23.855708","updated":"2026-09-09T12:50:23.855721","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1abdd79a-fa9b-4829-aba2-7017cd16ed75\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1abdd79a-fa9b-4829-aba2-7017cd16ed75/pipeline.log\">pipeline</a>"]},{"id":"0fc23981-6211-47e5-bef4-32e982323529","name":"CentOS Stream 9 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1106.170081,"created":"2026-09-14T12:06:00.559653","updated":"2026-09-14T12:06:00.559658","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0fc23981-6211-47e5-bef4-32e982323529\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0fc23981-6211-47e5-bef4-32e982323529/pipeline.log\">pipeline</a>"]},{"id":"5981e67c-7d73-44b6-a876-15ffb3ff7f05","name":"RHEL9 - FIPS Enabled - 24-minimal","status":"complete","outcome":"passed","runTime":5230.612638,"created":"2026-09-09T11:41:04.704299","updated":"2026-09-09T11:41:04.704307","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5981e67c-7d73-44b6-a876-15ffb3ff7f05\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5981e67c-7d73-44b6-a876-15ffb3ff7f05/pipeline.log\">pipeline</a>"]},{"id":"a3bceff1-4b1e-40db-91d5-60ead655fa83","name":"RHEL8 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":2070.182214,"created":"2026-09-14T11:47:15.794728","updated":"2026-09-14T11:47:15.794734","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a3bceff1-4b1e-40db-91d5-60ead655fa83\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a3bceff1-4b1e-40db-91d5-60ead655fa83/pipeline.log\">pipeline</a>"]},{"id":"b5b4b02b-d073-40f6-afda-b7ee5ba60eab","name":"RHEL8 - PyTest - 24","status":"complete","outcome":"passed","runTime":1920.553204,"created":"2026-09-14T11:47:17.986724","updated":"2026-09-14T11:47:17.986732","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5b4b02b-d073-40f6-afda-b7ee5ba60eab\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b5b4b02b-d073-40f6-afda-b7ee5ba60eab/pipeline.log\">pipeline</a>"]},{"id":"18157f83-d36d-4bd1-85d8-66e0e1a383fc","name":"CentOS Stream 10 - 24","status":"complete","outcome":"passed","runTime":884.74292,"created":"2026-09-14T11:25:41.281368","updated":"2026-09-14T11:25:41.281373","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/18157f83-d36d-4bd1-85d8-66e0e1a383fc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/18157f83-d36d-4bd1-85d8-66e0e1a383fc/pipeline.log\">pipeline</a>"]},{"id":"2ce5a802-ed96-479f-b68a-b3cf42509fda","name":"Fedora - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":928.495388,"created":"2026-09-14T11:47:17.121292","updated":"2026-09-14T11:47:17.121297","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2ce5a802-ed96-479f-b68a-b3cf42509fda\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2ce5a802-ed96-479f-b68a-b3cf42509fda/pipeline.log\">pipeline</a>"]},{"id":"0a1064d4-eb77-41b5-ae8a-501279e20381","name":"CentOS Stream 10 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1031.508978,"created":"2026-09-14T12:03:43.235757","updated":"2026-09-14T12:03:43.235764","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0a1064d4-eb77-41b5-ae8a-501279e20381\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0a1064d4-eb77-41b5-ae8a-501279e20381/pipeline.log\">pipeline</a>"]},{"id":"7f26c442-bc7a-419e-b2f7-16cc743ae7da","name":"CentOS Stream 10 - PyTest - 24","status":"complete","outcome":"passed","runTime":1124.945677,"created":"2026-09-14T11:50:46.373779","updated":"2026-09-14T11:50:46.373787","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7f26c442-bc7a-419e-b2f7-16cc743ae7da\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7f26c442-bc7a-419e-b2f7-16cc743ae7da/pipeline.log\">pipeline</a>"]},{"id":"67c26b38-0438-4a40-a4f9-455176184a71","name":"RHEL9 - FIPS Enabled - 22-minimal","status":"complete","outcome":"passed","runTime":6369.713303,"created":"2026-09-14T09:47:06.149341","updated":"2026-09-14T09:47:06.149349","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67c26b38-0438-4a40-a4f9-455176184a71\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67c26b38-0438-4a40-a4f9-455176184a71/pipeline.log\">pipeline</a>"]},{"id":"3753e592-4463-459c-a647-aed31bf0f0b1","name":"RHEL10 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1533.10596,"created":"2026-09-14T12:06:43.751971","updated":"2026-09-14T12:06:43.751980","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3753e592-4463-459c-a647-aed31bf0f0b1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3753e592-4463-459c-a647-aed31bf0f0b1/pipeline.log\">pipeline</a>"]},{"id":"cab2d351-f296-4335-a858-95406e61e568","name":"Fedora - 24","status":"complete","outcome":"passed","runTime":751.241238,"created":"2026-09-14T09:47:05.788047","updated":"2026-09-14T09:47:05.788054","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cab2d351-f296-4335-a858-95406e61e568\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cab2d351-f296-4335-a858-95406e61e568/pipeline.log\">pipeline</a>"]},{"id":"d26b2e39-69ae-467f-ad5e-327f1bfb48b5","name":"CentOS Stream 10 - 24-minimal","status":"complete","outcome":"passed","runTime":819.507432,"created":"2026-09-14T11:27:46.420719","updated":"2026-09-14T11:27:46.420731","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d26b2e39-69ae-467f-ad5e-327f1bfb48b5\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d26b2e39-69ae-467f-ad5e-327f1bfb48b5/pipeline.log\">pipeline</a>"]},{"id":"72c1f646-5fa8-4f18-9b59-96193107df2c","name":"Fedora - PyTest - 24","status":"complete","outcome":"passed","runTime":1069.467129,"created":"2026-09-14T11:47:17.547094","updated":"2026-09-14T11:47:17.547103","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/72c1f646-5fa8-4f18-9b59-96193107df2c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/72c1f646-5fa8-4f18-9b59-96193107df2c/pipeline.log\">pipeline</a>"]},{"id":"2693a3f7-6f9b-412a-b974-e3ac225b4547","name":"CentOS Stream 9 - 22","status":"complete","outcome":"passed","runTime":1018.713813,"created":"2026-09-14T11:28:20.881437","updated":"2026-09-14T11:28:20.881445","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2693a3f7-6f9b-412a-b974-e3ac225b4547\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2693a3f7-6f9b-412a-b974-e3ac225b4547/pipeline.log\">pipeline</a>"]},{"id":"a7566339-2e6a-4d27-b16f-9a6faf1afb01","name":"CentOS Stream 9 - 24-minimal","status":"complete","outcome":"passed","runTime":847.104943,"created":"2026-09-14T10:01:26.124528","updated":"2026-09-14T10:01:26.124536","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a7566339-2e6a-4d27-b16f-9a6faf1afb01\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a7566339-2e6a-4d27-b16f-9a6faf1afb01/pipeline.log\">pipeline</a>"]},{"id":"e6c6493e-abcd-403e-b23f-560fcfd46cc6","name":"RHEL8 - 24-minimal","status":"complete","outcome":"passed","runTime":5497.695675,"created":"2026-09-14T09:47:06.032773","updated":"2026-09-14T09:47:06.032783","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e6c6493e-abcd-403e-b23f-560fcfd46cc6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e6c6493e-abcd-403e-b23f-560fcfd46cc6/pipeline.log\">pipeline</a>"]},{"id":"cba83d8c-7ac8-4e58-a301-208a55cdb3ea","name":"RHEL8 - 22","status":"complete","outcome":"passed","runTime":1389.908466,"created":"2026-09-14T11:21:41.160100","updated":"2026-09-14T11:21:41.160162","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cba83d8c-7ac8-4e58-a301-208a55cdb3ea\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cba83d8c-7ac8-4e58-a301-208a55cdb3ea/pipeline.log\">pipeline</a>"]},{"id":"0efb1718-9456-4664-a3b8-b2fb27816307","name":"RHEL10 - Unsubscribed host - 22-minimal","status":"complete","outcome":"passed","runTime":1393.063466,"created":"2026-09-14T11:26:23.554259","updated":"2026-09-14T11:26:23.554266","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0efb1718-9456-4664-a3b8-b2fb27816307\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0efb1718-9456-4664-a3b8-b2fb27816307/pipeline.log\">pipeline</a>"]},{"id":"00aff2e5-8d5a-4f57-b50b-226008ec9be3","name":"RHEL10 - PyTest - 24","status":"complete","outcome":"passed","runTime":2094.098584,"created":"2026-09-14T11:47:15.334930","updated":"2026-09-14T11:47:15.334937","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/00aff2e5-8d5a-4f57-b50b-226008ec9be3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/00aff2e5-8d5a-4f57-b50b-226008ec9be3/pipeline.log\">pipeline</a>"]},{"id":"475ec57f-270d-4eef-b2a5-8228f861ee4c","name":"RHEL10 - 24-minimal","status":"complete","outcome":"passed","runTime":5602.553731,"created":"2026-09-14T09:47:22.482280","updated":"2026-09-14T09:47:22.482287","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/475ec57f-270d-4eef-b2a5-8228f861ee4c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/475ec57f-270d-4eef-b2a5-8228f861ee4c/pipeline.log\">pipeline</a>"]},{"id":"470ca88a-0be6-42e3-bf44-9fb9fe83ec4f","name":"RHEL10 - Unsubscribed host - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1624.826032,"created":"2026-09-14T11:52:36.373862","updated":"2026-09-14T11:52:36.373868","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/470ca88a-0be6-42e3-bf44-9fb9fe83ec4f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/470ca88a-0be6-42e3-bf44-9fb9fe83ec4f/pipeline.log\">pipeline</a>"]},{"id":"050e4157-2843-4a7a-a037-25e56f459973","name":"RHEL9 - Unsubscribed host - PyTest - 22","status":"complete","outcome":"passed","runTime":1590.318086,"created":"2026-09-14T12:16:38.823443","updated":"2026-09-14T12:16:38.823451","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/050e4157-2843-4a7a-a037-25e56f459973\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/050e4157-2843-4a7a-a037-25e56f459973/pipeline.log\">pipeline</a>"]},{"id":"bdd12f8f-49c9-43c2-b822-98579b1ccc9a","name":"RHEL9 - Unsubscribed host - PyTest - 24","status":"complete","outcome":"passed","runTime":1557.362684,"created":"2026-09-14T12:20:59.466008","updated":"2026-09-14T12:20:59.466013","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdd12f8f-49c9-43c2-b822-98579b1ccc9a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdd12f8f-49c9-43c2-b822-98579b1ccc9a/pipeline.log\">pipeline</a>"]},{"id":"c4593948-b5cb-4dcc-be71-b69fc6036ace","name":"Fedora - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":943.854217,"created":"2026-09-14T11:59:43.159098","updated":"2026-09-14T11:59:43.159103","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c4593948-b5cb-4dcc-be71-b69fc6036ace\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c4593948-b5cb-4dcc-be71-b69fc6036ace/pipeline.log\">pipeline</a>"]},{"id":"d795bfe4-9693-4c73-8066-32f56d1bbce1","name":"RHEL9 - Unsubscribed host - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1967.533572,"created":"2026-09-14T11:47:22.908372","updated":"2026-09-14T11:47:22.908383","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d795bfe4-9693-4c73-8066-32f56d1bbce1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d795bfe4-9693-4c73-8066-32f56d1bbce1/pipeline.log\">pipeline</a>"]},{"id":"01a0e252-66ea-4b43-b02d-398ab7e7b104","name":"RHEL9 - 24-minimal","status":"complete","outcome":"passed","runTime":6030.977833,"created":"2026-09-14T09:47:24.431669","updated":"2026-09-14T09:47:24.431675","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01a0e252-66ea-4b43-b02d-398ab7e7b104\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01a0e252-66ea-4b43-b02d-398ab7e7b104/pipeline.log\">pipeline</a>"]},{"id":"53c2b906-d620-473a-9209-e8cc346553cc","name":"RHEL9 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":6031.257939,"created":"2026-09-14T09:47:07.992872","updated":"2026-09-14T09:47:07.992880","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/53c2b906-d620-473a-9209-e8cc346553cc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/53c2b906-d620-473a-9209-e8cc346553cc/pipeline.log\">pipeline</a>"]},{"id":"21ec538d-fea5-4709-849c-4c4755d9ce49","name":"CentOS Stream 9 - PyTest - 24","status":"complete","outcome":"passed","runTime":1219.246659,"created":"2026-09-14T11:54:20.383202","updated":"2026-09-14T11:54:20.383209","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/21ec538d-fea5-4709-849c-4c4755d9ce49\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/21ec538d-fea5-4709-849c-4c4755d9ce49/pipeline.log\">pipeline</a>"]},{"id":"6c65c249-8dd2-4720-9d9e-885c84ef1905","name":"RHEL8 - 22-minimal","status":"complete","outcome":"passed","runTime":4173.783939,"created":"2026-09-14T10:17:51.357907","updated":"2026-09-14T10:17:51.357913","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6c65c249-8dd2-4720-9d9e-885c84ef1905\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6c65c249-8dd2-4720-9d9e-885c84ef1905/pipeline.log\">pipeline</a>"]},{"id":"74394c68-adb7-4c0a-b0c4-4b422d9eb59c","name":"RHEL9 - Unsubscribed host - 24","status":"complete","outcome":"passed","runTime":2172.394203,"created":"2026-09-14T11:16:01.169849","updated":"2026-09-14T11:16:01.169855","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/74394c68-adb7-4c0a-b0c4-4b422d9eb59c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/74394c68-adb7-4c0a-b0c4-4b422d9eb59c/pipeline.log\">pipeline</a>"]},{"id":"5c06956f-7ed4-4e32-b9ce-1da00b97c234","name":"RHEL9 - 22-minimal","status":"complete","outcome":"passed","runTime":2660.654432,"created":"2026-09-14T11:22:11.332749","updated":"2026-09-14T11:22:11.332758","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5c06956f-7ed4-4e32-b9ce-1da00b97c234\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5c06956f-7ed4-4e32-b9ce-1da00b97c234/pipeline.log\">pipeline</a>"]},{"id":"ad1a1d11-ca35-4a6d-86f7-570f7de739db","name":"RHEL9 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":5954.548041,"created":"2026-09-14T09:47:09.852504","updated":"2026-09-14T09:47:09.852512","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad1a1d11-ca35-4a6d-86f7-570f7de739db\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad1a1d11-ca35-4a6d-86f7-570f7de739db/pipeline.log\">pipeline</a>"]},{"id":"8f2413bb-899a-4bd3-b1fb-ba1a84bcf9cc","name":"RHEL9 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":2380.911176,"created":"2026-09-14T11:47:17.652905","updated":"2026-09-14T11:47:17.652914","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8f2413bb-899a-4bd3-b1fb-ba1a84bcf9cc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8f2413bb-899a-4bd3-b1fb-ba1a84bcf9cc/pipeline.log\">pipeline</a>"]},{"id":"0b650c6d-788b-48da-b9bf-8c9f2c3e0b4d","name":"RHEL9 - PyTest - 24","status":"complete","outcome":"passed","runTime":2359.804445,"created":"2026-09-14T11:47:25.647712","updated":"2026-09-14T11:47:25.647718","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0b650c6d-788b-48da-b9bf-8c9f2c3e0b4d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0b650c6d-788b-48da-b9bf-8c9f2c3e0b4d/pipeline.log\">pipeline</a>"]},{"id":"a1607289-120e-4b41-8775-c26fade56aa0","name":"CentOS Stream 10 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":991.3862,"created":"2026-09-14T11:47:30.762627","updated":"2026-09-14T11:47:30.762635","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a1607289-120e-4b41-8775-c26fade56aa0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a1607289-120e-4b41-8775-c26fade56aa0/pipeline.log\">pipeline</a>"]},{"id":"c172083c-5146-43c2-b961-23eac8d39101","name":"CentOS Stream 9 - 22-minimal","status":"complete","outcome":"passed","runTime":850.30671,"created":"2026-09-14T11:25:49.611713","updated":"2026-09-14T11:25:49.611718","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c172083c-5146-43c2-b961-23eac8d39101\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c172083c-5146-43c2-b961-23eac8d39101/pipeline.log\">pipeline</a>"]},{"id":"dc1106f9-f250-4f12-9dbc-d6a34db1b65d","name":"RHEL9 - PyTest - 22","runTime":2614.103224,"created":"2026-09-14T12:16:04.646929","updated":"2026-09-14T12:16:04.646935","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dc1106f9-f250-4f12-9dbc-d6a34db1b65d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dc1106f9-f250-4f12-9dbc-d6a34db1b65d/pipeline.log\">pipeline</a>"]},{"id":"3fb2e7ae-106b-46d6-9a76-fc1372ae6924","name":"Fedora - 22-minimal","status":"complete","outcome":"passed","runTime":716.588318,"created":"2026-09-14T11:21:44.436861","updated":"2026-09-14T11:21:44.436872","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3fb2e7ae-106b-46d6-9a76-fc1372ae6924\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3fb2e7ae-106b-46d6-9a76-fc1372ae6924/pipeline.log\">pipeline</a>"]},{"id":"80b1c858-faf7-4927-a0f3-d1cfff51a2bb","name":"CentOS Stream 10 - PyTest - 22","status":"complete","outcome":"passed","runTime":1138.267896,"created":"2026-09-14T12:08:31.498882","updated":"2026-09-14T12:08:31.498888","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/80b1c858-faf7-4927-a0f3-d1cfff51a2bb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/80b1c858-faf7-4927-a0f3-d1cfff51a2bb/pipeline.log\">pipeline</a>"]},{"id":"dc3c758e-be86-401e-8099-344981111a8b","name":"Fedora - 22","status":"complete","outcome":"passed","runTime":829.651043,"created":"2026-09-14T09:47:24.846485","updated":"2026-09-14T09:47:24.846492","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/dc3c758e-be86-401e-8099-344981111a8b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/dc3c758e-be86-401e-8099-344981111a8b/pipeline.log\">pipeline</a>"]},{"id":"904dc60c-3d6c-45c9-8256-a3367c27844e","name":"CentOS Stream 9 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1076.033932,"created":"2026-09-14T12:11:10.638154","updated":"2026-09-14T12:11:10.638162","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/904dc60c-3d6c-45c9-8256-a3367c27844e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/904dc60c-3d6c-45c9-8256-a3367c27844e/pipeline.log\">pipeline</a>"]},{"id":"cd36226b-ea36-4dc8-88fa-ae4a81051ce1","name":"Fedora - 24-minimal","status":"complete","outcome":"passed","runTime":721.756669,"created":"2026-09-14T11:29:50.545902","updated":"2026-09-14T11:29:50.545909","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/cd36226b-ea36-4dc8-88fa-ae4a81051ce1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/cd36226b-ea36-4dc8-88fa-ae4a81051ce1/pipeline.log\">pipeline</a>"]},{"id":"cab397ad-b9ef-4192-8d8c-d8bc471406ca","name":"RHEL9 - Unsubscribed host - 22-minimal","status":"complete","outcome":"passed","runTime":5657.988661,"created":"2026-09-14T10:01:51.571211","updated":"2026-09-14T10:01:51.571219","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cab397ad-b9ef-4192-8d8c-d8bc471406ca\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cab397ad-b9ef-4192-8d8c-d8bc471406ca/pipeline.log\">pipeline</a>"]},{"id":"53293bb1-4a12-4092-a1e7-18483b9df36f","name":"RHEL10 - 22","status":"complete","outcome":"passed","runTime":5779.64545,"created":"2026-09-14T09:47:08.910050","updated":"2026-09-14T09:47:08.910057","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/53293bb1-4a12-4092-a1e7-18483b9df36f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/53293bb1-4a12-4092-a1e7-18483b9df36f/pipeline.log\">pipeline</a>"]},{"id":"19a11bec-2425-48ad-b181-5dbbdd46ca58","name":"RHEL10 - Unsubscribed host - PyTest - 22","status":"complete","outcome":"passed","runTime":1812.216242,"created":"2026-09-14T11:47:15.608666","updated":"2026-09-14T11:47:15.608674","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/19a11bec-2425-48ad-b181-5dbbdd46ca58\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/19a11bec-2425-48ad-b181-5dbbdd46ca58/pipeline.log\">pipeline</a>"]},{"id":"61979241-b9be-4993-9d9d-8dfc9fe8d7db","name":"RHEL10 - PyTest - 22","status":"complete","outcome":"passed","runTime":2099.880687,"created":"2026-09-14T11:48:01.191542","updated":"2026-09-14T11:48:01.191550","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/61979241-b9be-4993-9d9d-8dfc9fe8d7db\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/61979241-b9be-4993-9d9d-8dfc9fe8d7db/pipeline.log\">pipeline</a>"]},{"id":"ad4a3f9e-f52e-4b53-bb80-edc764453eb7","name":"RHEL9 - PyTest - 24-minimal","status":"complete","outcome":"passed","runTime":1925.969862,"created":"2026-09-14T12:16:28.136780","updated":"2026-09-14T12:16:28.136788","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad4a3f9e-f52e-4b53-bb80-edc764453eb7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad4a3f9e-f52e-4b53-bb80-edc764453eb7/pipeline.log\">pipeline</a>"]},{"id":"6f5eb0dc-4b3a-4512-a6a4-2ddfd3d71f0c","name":"RHEL8 - PyTest - 22","status":"complete","outcome":"passed","runTime":1460.245354,"created":"2026-09-14T12:19:42.021193","updated":"2026-09-14T12:19:42.021201","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f5eb0dc-4b3a-4512-a6a4-2ddfd3d71f0c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f5eb0dc-4b3a-4512-a6a4-2ddfd3d71f0c/pipeline.log\">pipeline</a>"]},{"id":"70a5005f-338e-4955-b54f-2911cb1635cb","name":"RHEL9 - Unsubscribed host - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1503.729777,"created":"2026-09-14T12:00:29.291176","updated":"2026-09-14T12:00:29.291183","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/70a5005f-338e-4955-b54f-2911cb1635cb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/70a5005f-338e-4955-b54f-2911cb1635cb/pipeline.log\">pipeline</a>"]},{"id":"83710369-4ace-4b67-8715-59aeca9426ef","name":"RHEL10 - 24","status":"complete","outcome":"passed","runTime":4959.977542,"created":"2026-09-14T10:04:54.305328","updated":"2026-09-14T10:04:54.305338","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/83710369-4ace-4b67-8715-59aeca9426ef\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/83710369-4ace-4b67-8715-59aeca9426ef/pipeline.log\">pipeline</a>"]},{"id":"c63ed5da-fed6-4d36-b90b-2346860523f1","name":"CentOS Stream 10 - 22-minimal","status":"complete","outcome":"passed","runTime":768.162284,"created":"2026-09-14T11:33:34.821884","updated":"2026-09-14T11:33:34.821890","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c63ed5da-fed6-4d36-b90b-2346860523f1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c63ed5da-fed6-4d36-b90b-2346860523f1/pipeline.log\">pipeline</a>"]},{"id":"c0165047-20f3-47aa-8b51-cb21c8225e2f","name":"RHEL10 - Unsubscribed host - 24-minimal","status":"complete","outcome":"passed","runTime":5538.776123,"created":"2026-09-14T09:47:06.755650","updated":"2026-09-14T09:47:06.755658","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0165047-20f3-47aa-8b51-cb21c8225e2f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c0165047-20f3-47aa-8b51-cb21c8225e2f/pipeline.log\">pipeline</a>"]},{"id":"97b6cb68-b780-4daa-9530-37e8cfce96d2","name":"RHEL8 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1364.508147,"created":"2026-09-14T12:11:16.055957","updated":"2026-09-14T12:11:16.055963","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/97b6cb68-b780-4daa-9530-37e8cfce96d2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/97b6cb68-b780-4daa-9530-37e8cfce96d2/pipeline.log\">pipeline</a>"]},{"id":"4bd83ba6-7d38-4aaa-afb7-682c94645c63","name":"RHEL10 - PyTest - 22-minimal","status":"complete","outcome":"passed","runTime":1618.329847,"created":"2026-09-14T11:47:59.745828","updated":"2026-09-14T11:47:59.745835","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bd83ba6-7d38-4aaa-afb7-682c94645c63\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4bd83ba6-7d38-4aaa-afb7-682c94645c63/pipeline.log\">pipeline</a>"]},{"id":"a1f86d1b-0a9c-41e4-8bca-1d64667bdcf7","name":"RHEL10 - Unsubscribed host - 22","status":"complete","outcome":"passed","runTime":1735.166427,"created":"2026-09-14T11:20:15.491007","updated":"2026-09-14T11:20:15.491013","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a1f86d1b-0a9c-41e4-8bca-1d64667bdcf7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a1f86d1b-0a9c-41e4-8bca-1d64667bdcf7/pipeline.log\">pipeline</a>"]},{"id":"69b81e3d-1383-4dca-9b4d-d2ed7e53fb40","name":"RHEL9 - FIPS Enabled - 24","status":"complete","outcome":"passed","runTime":6335.555127,"created":"2026-09-14T09:47:22.988760","updated":"2026-09-14T09:47:22.988768","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/69b81e3d-1383-4dca-9b4d-d2ed7e53fb40\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/69b81e3d-1383-4dca-9b4d-d2ed7e53fb40/pipeline.log\">pipeline</a>"]},{"id":"a1a9cc05-2074-4406-b54e-2da77ceee20f","name":"RHEL9 - FIPS Enabled - 22","status":"complete","outcome":"passed","runTime":7849.506736,"created":"2026-09-14T09:47:06.017245","updated":"2026-09-14T09:47:06.017253","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a1a9cc05-2074-4406-b54e-2da77ceee20f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a1a9cc05-2074-4406-b54e-2da77ceee20f/pipeline.log\">pipeline</a>"]},{"id":"45b618c8-6259-4697-be84-0407eec27b2c","name":"RHEL9 - 24","status":"complete","outcome":"passed","runTime":1785.096392,"created":"2026-09-14T11:30:01.945948","updated":"2026-09-14T11:30:01.945957","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/45b618c8-6259-4697-be84-0407eec27b2c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/45b618c8-6259-4697-be84-0407eec27b2c/pipeline.log\">pipeline</a>"]},{"id":"e1acf1d3-a893-4dec-85e6-8ee68e972252","name":"RHEL10 - Unsubscribed host - PyTest - 24","status":"complete","outcome":"passed","runTime":1767.753098,"created":"2026-09-14T12:05:47.014104","updated":"2026-09-14T12:05:47.014148","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e1acf1d3-a893-4dec-85e6-8ee68e972252\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e1acf1d3-a893-4dec-85e6-8ee68e972252/pipeline.log\">pipeline</a>"]}]} -->